### PR TITLE
Add external secret to manifest

### DIFF
--- a/manifests/base/externalsecret.yaml
+++ b/manifests/base/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: janus-idp
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        key: moc/smaug/janus-idp/values-app-config
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: opf-vault-store
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: janus-idp


### PR DESCRIPTION
## What does this PR do / why we need it
This PR adds the external secret to the manifests to allow the ability to retrieve secrets from vault during deployment.

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
