### PR TITLE
Add backstage label for Kubernetes

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "janus-idp"
   labels: 
     app.kubernetes.io/component: backstage
+    backstage.io/kubernetes-id: janus-idp
 spec:
   replicas: 1
   selector:

--- a/manifests/base/ingress.yaml
+++ b/manifests/base/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "janus-idp"
   labels:
     app.kubernetes.io/component: backstage
-  annotations:
+    backstage.io/kubernetes-id: janus-idp
 spec:
   tls:
     - hosts:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "janus-idp" 
   labels:
     app.kubernetes.io/component: backstage
+    backstage.io/kubernetes-id: janus-idp
 spec:
   type: ClusterIP
   sessionAffinity: None


### PR DESCRIPTION
## What does this PR do / why we need it
Adding the label `backstage.io/kubernetes-id: janus-idp` to the backstage deployment, ingress, and service will allow these resources to be discovered by the Kubernetes plugin. Also, the cluster token has already been fixed.
## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
