### PR TITLE
Add kubernetes label to pod

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: backstage
+        backstage.io/kubernetes-id: janus-idp
       annotations:
         checksum/app-config: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
     spec:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -12,5 +12,4 @@ labels:
   - pairs:
       app.kubernetes.io/name: backstage
       app.kubernetes.io/instance: backstage
-      backstage.io/kubernetes-id: backstage
     includeSelectors: false


### PR DESCRIPTION
## What does this PR do / why we need it
Small fix that will add the Backstage Kubernetes label to the pod for discovery by the Kubernetes plugin
## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
