### PR TITLE
Revert to commonLabels

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,8 +8,6 @@ resources:
   - externalsecret.yaml
   - issuer.yaml
   - certificate.yaml
-labels:
-  - pairs:
-      app.kubernetes.io/name: backstage
-      app.kubernetes.io/instance: backstage
-    includeSelectors: false
+commonLabels:
+    app.kubernetes.io/name: backstage
+    app.kubernetes.io/instance: backstage


### PR DESCRIPTION
## What does this PR do / why we need it
It looks like the update to use 
```
labels:
  - pairs:
      app.kubernetes.io/name: backstage
      app.kubernetes.io/instance: backstage
    includeSelectors: false
```
is causing a sync issue in ArgoCD. Reverting back to the use of the `commonLabels` in an attempt to fix the sync issue.
## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
