### PR TITLE
Update the ingress with new domain

### DIFF
--- a/catalog-entities/components.yaml
+++ b/catalog-entities/components.yaml
@@ -8,7 +8,7 @@ metadata:
     - title: Janus Website
       url: https://janus-idp.io
     - title: Janus Showcase
-      url: https://janus-idp.apps.smaug.na.operate-first.cloud/
+      url: https://showcase.janus-idp.io/
   annotations:
     argocd/app-name: "janus-idp-smaug"
     backstage.io/kubernetes-id: "janus-idp"

--- a/manifests/base/certificate.yaml
+++ b/manifests/base/certificate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ssl-certificate
 spec:
   dnsNames:
-    - janus-idp.apps.smaug.na.operate-first.cloud
+    - showcase.janus-idp.io
   issuerRef:
     name: letsencrypt
   secretName: janus-idp-cert

--- a/manifests/base/ingress.yaml
+++ b/manifests/base/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   tls:
     - hosts:
-      - janus-idp.apps.smaug.na.operate-first.cloud
+      - showcase.janus-idp.io
       secretName: janus-idp-cert
   rules:
-    - host: janus-idp.apps.smaug.na.operate-first.cloud
+    - host: showcase.janus-idp.io
       http:
         paths:
           - path: /

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - externalsecret.yaml
   - issuer.yaml
   - certificate.yaml
+  - keycloak
 commonLabels:
     app.kubernetes.io/name: backstage
     app.kubernetes.io/instance: backstage


### PR DESCRIPTION
## What does this PR do / why we need it
This is to update the Ingress with the new domain that was created. Also updates the URL for the showcase app in the `component.yaml` 

Additionally, there was an issue with the Keycloak missing from the kustomize file leading to it not being deployed.
## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
