### PR TITLE
Manifest changes

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -39,3 +39,13 @@ spec:
             - name: backend
               containerPort: 7007
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 7007
+              scheme: HTTP
+            initialDelaySeconds: 3
+            timeoutSeconds: 1
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3

--- a/manifests/base/keycloak/certificate.yaml
+++ b/manifests/base/keycloak/certificate.yaml
@@ -1,10 +1,10 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ssl-certificate
+  name: keycloak-certificate
 spec:
   dnsNames:
-    - keycloak-janus-idp.apps.smaug.na.operate-first.cloud
+    - keycloak.apps.smaug.na.operate-first.cloud
   issuerRef:
     name: letsencrypt
   secretName: keycloak-cert

--- a/manifests/base/keycloak/ingress.yaml
+++ b/manifests/base/keycloak/ingress.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   tls:
     - hosts: 
-      - keycloak-janus-idp.apps.smaug.na.operate-first.cloud
+      - keycloak.apps.smaug.na.operate-first.cloud
       secretName: keycloak-cert
   rules:
-    - host: keycloak-janus-idp.apps.smaug.na.operate-first.cloud
+    - host: keycloak.apps.smaug.na.operate-first.cloud
       http:
         paths:
           - pathType: Prefix

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - externalsecret.yaml
   - issuer.yaml
   - certificate.yaml
+  - keycloak
 commonLabels:
     app.kubernetes.io/name: backstage
     app.kubernetes.io/instance: backstage

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: janus-idp
+resources: 
+  - ../../base

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: janus-idp
+resources: 
+  - ../../base


### PR DESCRIPTION
## What does this PR do / why we need it
This PR is meant to update the manifests for the Backstage Showcase app
First is to add multiple environments that will be used for deployment

* This will allow us to test new changes in a dev environment without affect what is currently deployed in the prod environment

Second is to add a readiness probe to the deployment resource

* This is to fix the issue of bringing down the app whenever there is a failing deployment

* The cluster will first check if the new pod is ready before scaling down the old pod

Third is to fix an issue with the Keycloak cert

* Renamed to avoid conflict 

* Shortened the URL to avoid the issue of it being too long for certification
## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
