### PR TITLE
feat: Change image repository to quay

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,9 +23,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: quay.io
+  PASSWORD_KEY: QUAY_TOKEN
+  USERNAME: ${{ vars.QUAY_USERNAME }}
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_TAGS: latest ${{ github.sha }}
 
 jobs:
   docker-build:
@@ -48,20 +49,22 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.USERNAME }}
+          password: ${{ secrets[env.PASSWORD_KEY] }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=true
+          tags: type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/catalog-entities/components.yaml
+++ b/catalog-entities/components.yaml
@@ -13,7 +13,7 @@ metadata:
     argocd/app-name: "janus-idp-smaug"
     backstage.io/kubernetes-id: "janus-idp"
     github.com/project-slug: janus-idp/backstage-showcase
-    quay.io/repository-slug: janus-idp/redhat-backstage-build
+    quay.io/repository-slug: janus-idp/backstage-showcase
 spec:
   type: website
   owner: janus-authors

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             requests:
               cpu: 400m
           name: backstage-showcase
-          image: ghcr.io/janus-idp/backstage-showcase:main
+          image: backstage-showcase
           imagePullPolicy: "Always"
           command:
             - node

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -12,3 +12,6 @@ resources:
 commonLabels:
     app.kubernetes.io/name: backstage
     app.kubernetes.io/instance: backstage
+images:
+  - name: backstage-showcase
+    newName: quay.io/janus-idp/backstage-showcase


### PR DESCRIPTION
WIP: Still resolving permissions.

## What does this PR do / why we need it
Change image repository in the build workflow. Add the new image to the deployment manifest and replace the quay slug in catalog.

## Which issue(s) does this PR fix

Fixes #81

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
I've tested the workflow in my personal repo, the resulting image can be seen here: https://quay.io/repository/skopecky/backstage-showcase-test?tab=tags