### PR TITLE
Change ArgoCD URL to be a variable

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -49,7 +49,7 @@ proxy:
   #   target: 'https://example.com'
   #   changeOrigin: true
   '/argocd/api':
-    target: https://argocd.operate-first.cloud/api/v1/
+    target: ${ARGOCD_URL}
     changeOrigin: true
     secure: true
     headers:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,15 @@ The easiest and fastest method for getting started with the Backstage Showcase a
          apps:
            - $include: github-app-backstage-showcase-credentials.local.yaml
 
+   proxy:
+     '/argocd/api':
+       target: ${ARGOCD_URL}
+       changeOrigin: true
+       secure: true
+       headers:
+         Cookie:
+           $env: ARGOCD_AUTH_TOKEN
+
    auth:
      environment: development
      providers:
@@ -73,6 +82,11 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      - This [URL](https://backstage.io/docs/integrations/github/github-apps) can be used to quickly create a GitHub app, you can name the yaml file `github-app-backstage-showcase-credentials.local.yaml`
      - `${GITHUB_APP_CLIENT_ID}` with the client id
      - `${GITHUB_APP_CLIENT_SECRET}` with the client secret
+
+   - Setup an ArgoCD instance (Needed for the ArgoCD plugin) and replace the following variables
+
+     - `${ARGOCD_URL}` with the URL to the instance
+     - `${ARGOCD_AUTH_TOKEN}` with the token to the instance
 
    - Setup a Keycloak instance (Needed for the Keycloak plugin) and replace the following variables
 


### PR DESCRIPTION
## Description

Updated the hard coded ArgoCD URL to now be a variable to allow for more customization. 

## Which issue(s) does this PR fix

- Fixes #100

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
