### PR TITLE
Argocd backend plugin

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,13 +48,6 @@ proxy:
   # '/test':
   #   target: 'https://example.com'
   #   changeOrigin: true
-  '/argocd/api':
-    target: ${ARGOCD_URL}
-    changeOrigin: true
-    secure: true
-    headers:
-      Cookie:
-        $env: ARGOCD_AUTH_TOKEN
   '/quay/api':
     target: https://quay.io/
     headers:
@@ -164,3 +157,16 @@ ocm:
     name: ${OCM_HUB_NAME}
     url: ${OCM_HUB_URL}
     serviceAccountToken: ${moc_infra_token}
+
+argocd:
+  username: ${ARGOCD_USERNAME}
+  password: ${ARGOCD_PASSWORD}
+  appLocatorMethods:
+    - type: 'config'
+      instances:
+        - name: argoInstance1
+          url: ${ARGOCD_INSTANCE1_URL}
+          token: ${ARGOCD_AUTH_TOKEN}
+        - name: argoInstance2
+          url: ${ARGOCD_INSTANCE2_URL}
+          token: ${ARGOCD_AUTH_TOKEN2}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,15 +31,6 @@ The easiest and fastest method for getting started with the Backstage Showcase a
          apps:
            - $include: github-app-backstage-showcase-credentials.local.yaml
 
-   proxy:
-     '/argocd/api':
-       target: ${ARGOCD_URL}
-       changeOrigin: true
-       secure: true
-       headers:
-         Cookie:
-           $env: ARGOCD_AUTH_TOKEN
-
    auth:
      environment: development
      providers:
@@ -75,6 +66,19 @@ The easiest and fastest method for getting started with the Backstage Showcase a
        name: ${OCM_HUB_NAME}
        url: ${OCM_HUB_URL}
        serviceAccountToken: ${moc_infra_token}
+
+   argocd:
+     username: ${ARGOCD_USERNAME}
+     password: ${ARGOCD_PASSWORD}
+     appLocatorMethods:
+       - type: 'config'
+         instances:
+           - name: argoInstance1
+             url: ${ARGOCD_INSTANCE1_URL}
+             token: ${ARGOCD_AUTH_TOKEN}
+           - name: argoInstance2
+             url: ${ARGOCD_INSTANCE2_URL}
+             token: ${ARGOCD_AUTH_TOKEN2}
    ```
 
    - Setup a GitHub app (Needed for the GitHub Issues, GitHub Pull Request plugins) and replace the variables
@@ -83,10 +87,16 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      - `${GITHUB_APP_CLIENT_ID}` with the client id
      - `${GITHUB_APP_CLIENT_SECRET}` with the client secret
 
-   - Setup an ArgoCD instance (Needed for the ArgoCD plugin) and replace the following variables
+   - Setup one to two ArgoCD instances (Needed for the ArgoCD backend plugin) and replace the following variables
 
-     - `${ARGOCD_URL}` with the URL to the instance
+     - If using a shared username and password across the instances, you can define them in the username and password variables and arbitrarily assign the urls and tokens
+     - If using tokens for each individual instance, you can assign arbitrary variables to the tokens
+     - `${ARGOCD_USERNAME}` Username for the instance(s)
+     - `${ARGOCD_PASSWORD}` Password for the instance(s)
+     - `${ARGOCD_INSTANCE1_URL}` with the URL to the instance
      - `${ARGOCD_AUTH_TOKEN}` with the token to the instance
+     - `${ARGOCD_INSTANCE2_URL}` with the URL to the instance
+     - `${ARGOCD_AUTH_TOKEN2}` with the token to the instance
 
    - Setup a Keycloak instance (Needed for the Keycloak plugin) and replace the following variables
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,6 +36,8 @@
     "@backstage/plugin-techdocs-backend": "^1.5.3",
     "@janus-idp/backstage-plugin-keycloak-backend": "^1.0.3",
     "@janus-idp/backstage-plugin-ocm-backend": "^1.3.0",
+    "@roadiehq/backstage-plugin-argo-cd-backend": "^2.7.1",
+    "@roadiehq/scaffolder-backend-argocd": "^1.1.5",
     "app": "link:../app",
     "better-sqlite3": "^8.0.0",
     "dockerode": "^3.3.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "@backstage/catalog-client": "^1.3.1",
     "@backstage/catalog-model": "^1.2.0",
     "@backstage/config": "^1.0.6",
+    "@backstage/integration": "^1.4.2",
     "@backstage/plugin-app-backend": "^0.3.42",
     "@backstage/plugin-auth-backend": "^0.18.0",
     "@backstage/plugin-auth-node": "^0.2.11",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -33,6 +33,7 @@ import { PluginEnvironment } from './types';
 import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 import { DefaultIdentityClient } from '@backstage/plugin-auth-node';
 import ocm from './plugins/ocm';
+import argocd from './plugins/argocd';
 
 function makeCreateEnv(config: Config) {
   const root = getRootLogger();
@@ -89,6 +90,7 @@ async function main() {
   const appEnv = useHotMemoize(module, () => createEnv('app'));
   const kubernetesEnv = useHotMemoize(module, () => createEnv('kubernetes'));
   const ocmEnv = useHotMemoize(module, () => createEnv('ocm'));
+  const argocdEnv = useHotMemoize(module, () => createEnv('argocd'));
 
   const apiRouter = Router();
   apiRouter.use('/catalog', await catalog(catalogEnv));
@@ -99,6 +101,7 @@ async function main() {
   apiRouter.use('/search', await search(searchEnv));
   apiRouter.use('/kubernetes', await kubernetes(kubernetesEnv));
   apiRouter.use('/ocm', await ocm(ocmEnv));
+  apiRouter.use('/argocd', await argocd(argocdEnv));
 
   // Add backends ABOVE this line; this 404 handler is the catch-all fallback
   apiRouter.use(notFoundHandler());

--- a/packages/backend/src/plugins/argocd.ts
+++ b/packages/backend/src/plugins/argocd.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@roadiehq/backstage-plugin-argo-cd-backend';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin({
+  logger,
+  config,
+}: PluginEnvironment) {
+  return await createRouter({ logger, config });
+}

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -1,7 +1,12 @@
 import { CatalogClient } from '@backstage/catalog-client';
-import { createRouter } from '@backstage/plugin-scaffolder-backend';
+import {
+  createBuiltinActions,
+  createRouter,
+} from '@backstage/plugin-scaffolder-backend';
 import { Router } from 'express';
 import type { PluginEnvironment } from '../types';
+import { ScmIntegrations } from '@backstage/integration';
+import { createArgoCdResources } from '@roadiehq/scaffolder-backend-argocd';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -9,8 +14,22 @@ export default async function createPlugin(
   const catalogClient = new CatalogClient({
     discoveryApi: env.discovery,
   });
+  const integrations = ScmIntegrations.fromConfig(env.config);
+
+  const builtInActions = createBuiltinActions({
+    integrations,
+    catalogClient,
+    config: env.config,
+    reader: env.reader,
+  });
+
+  const actions = [
+    ...builtInActions,
+    createArgoCdResources(env.config, env.logger),
+  ];
 
   return await createRouter({
+    actions,
     logger: env.logger,
     config: env.config,
     database: env.database,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10630,6 +10630,7 @@ __metadata:
     "@backstage/catalog-model": ^1.2.0
     "@backstage/cli": ^0.22.3
     "@backstage/config": ^1.0.6
+    "@backstage/integration": ^1.4.2
     "@backstage/plugin-app-backend": ^0.3.42
     "@backstage/plugin-auth-backend": ^0.18.0
     "@backstage/plugin-auth-node": ^0.2.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -7211,6 +7211,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@roadiehq/backstage-plugin-argo-cd-backend@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:2.7.1"
+  dependencies:
+    "@backstage/backend-common": ^0.18.2
+    "@backstage/catalog-client": ^1.3.1
+    "@backstage/config": ^1.0.6
+    "@types/express": ^4.17.6
+    cross-fetch: ^3.1.4
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    winston: ^3.2.1
+    yn: ^4.0.0
+  checksum: 5ba0a5a008ea18ecd1147c83e7097e352285e816cfa8df5b0b214ce0402108f93e3ac9fc751e1c148671d9aeec66d55f225553162b59f505b0f27be9dfa8b87b
+  languageName: node
+  linkType: hard
+
 "@roadiehq/backstage-plugin-argo-cd@npm:^2.2.6":
   version: 2.2.6
   resolution: "@roadiehq/backstage-plugin-argo-cd@npm:2.2.6"
@@ -7323,6 +7340,19 @@ __metadata:
     react-dom: ^16.13.1 || ^17.0.0
     react-router: 6.0.0-beta.0 || ^6.3.0
   checksum: 04c02c807ea9c3099dcd0c64c811ed999d188c660a497b46bff95b7e9704d994a0ae194d1f068b410449e7ce558aaf54bd869135720cdac35753a054402a6533
+  languageName: node
+  linkType: hard
+
+"@roadiehq/scaffolder-backend-argocd@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@roadiehq/scaffolder-backend-argocd@npm:1.1.5"
+  dependencies:
+    "@backstage/backend-common": ^0.18.2
+    "@backstage/config": ^1.0.6
+    "@backstage/plugin-scaffolder-backend": ^1.11.0
+    "@roadiehq/backstage-plugin-argo-cd-backend": ^2.7.1
+    winston: ^3.2.1
+  checksum: 5bdc221872797d5c3896dc027d020cec62f2600a6fcbb2a9f4d5c5150ea937b51bdf828c80b54099106de7f4289c10477c8c322723bb32f456096bad1e1e6330
   languageName: node
   linkType: hard
 
@@ -10615,6 +10645,8 @@ __metadata:
     "@backstage/plugin-techdocs-backend": ^1.5.3
     "@janus-idp/backstage-plugin-keycloak-backend": ^1.0.3
     "@janus-idp/backstage-plugin-ocm-backend": ^1.3.0
+    "@roadiehq/backstage-plugin-argo-cd-backend": ^2.7.1
+    "@roadiehq/scaffolder-backend-argocd": ^1.1.5
     "@types/dockerode": ^3.3.0
     "@types/express": ^4.17.6
     "@types/express-serve-static-core": ^4.17.5


### PR DESCRIPTION
## Description

This PR adds the scaffolder ArgoCD action for creating ArgoCD resources as well as the ArgoCD backend plugin. 

## Which issue(s) does this PR fix

- Fixes #101 

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
I added another variable for the url ARGOCD_INSTANCE1_URL. The reasoning is because the frontend plugin requires `api/v1` to be added to the URL, while the backend plugin will throw an error if `api/v1` is on the tail end of the URL. This way we can add the ARGOCD_INSTANCE1_URL and then remove / update the ARGOCD_URL variable whenever the changes go live. 