### PR TITLE
enabled default github identity resolver

### DIFF
--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -37,16 +37,16 @@ export default async function createPlugin(
       //   https://backstage.io/docs/auth/identity-resolver
       github: providers.github.create({
         signIn: {
-          resolver(_, ctx) {
-            const userRef = 'user:default/guest'; // Must be a full entity reference
-            return ctx.issueToken({
-              claims: {
-                sub: userRef, // The user's own identity
-                ent: [userRef], // A list of identities that the user claims ownership through
-              },
-            });
-          },
-          // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+          // resolver(_, ctx) {
+          //   const userRef = 'user:default/guest'; // Must be a full entity reference
+          //   return ctx.issueToken({
+          //     claims: {
+          //       sub: userRef, // The user's own identity
+          //       ent: [userRef], // A list of identities that the user claims ownership through
+          //     },
+          //   });
+          // },
+          resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),
     },

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -37,15 +37,6 @@ export default async function createPlugin(
       //   https://backstage.io/docs/auth/identity-resolver
       github: providers.github.create({
         signIn: {
-          // resolver(_, ctx) {
-          //   const userRef = 'user:default/guest'; // Must be a full entity reference
-          //   return ctx.issueToken({
-          //     claims: {
-          //       sub: userRef, // The user's own identity
-          //       ent: [userRef], // A list of identities that the user claims ownership through
-          //     },
-          //   });
-          // },
           resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),


### PR DESCRIPTION
## Description

enabled default github identity resolver. This change worked for me. But it may need some conditional logic to coexist with other identity resolved. Basically one can assume that given how a user was authenticated, there is an identity resolved that applies better than others. And then perhaps have a default one (the one I commented out).
Not sure how to write that conditional logic. This is better tested only after #120 is merged and it needs that data to do the mapping.

## Which issue(s) does this PR fix

- Fixes #116 

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
