### PR TITLE
Techdocs CI

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -1,0 +1,42 @@
+name: Publish TechDocs Site
+
+on:
+  push:
+    branches:
+      - main
+      - techdocs-ci
+
+
+jobs:
+  publish-techdocs-site:
+    runs-on: ubuntu-latest
+
+    env:
+      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ENTITY_NAMESPACE: 'default'
+      ENTITY_KIND: 'Component'
+      ENTITY_NAME: 'backstage-showcase'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install techdocs-cli
+        run: sudo npm install -g @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==1.*
+
+      - name: Generate docs site
+        run: techdocs-cli generate --no-docker --verbose
+
+      - name: Publish docs site
+        run: techdocs-cli publish --publisher-type awsS3 --storage-name $TECHDOCS_S3_BUCKET_NAME --entity $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-      - techdocs-ci
+    paths:
+      - "docs/**"
+      - "mkdocs.yaml"
 
 
 jobs:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -62,11 +62,18 @@ proxy:
 # and an external cloud storage when deploying TechDocs for production use-case.
 # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
 techdocs:
-  builder: 'local' # Alternatives - 'external'
+  builder: 'external'
   generator:
-    runIn: 'docker' # Alternatives - 'local'
+    runIn: 'local'
   publisher:
-    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+    type: 'awsS3'
+    awsS3:
+      bucketName: ${BUCKET_NAME}
+      region: ${BUCKET_REGION}
+      endpoint: https://s3-openshift-storage.apps.smaug.na.operate-first.cloud
+      credentials:
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers

--- a/showcase-docs/getting-started.md
+++ b/showcase-docs/getting-started.md
@@ -31,6 +31,13 @@ The easiest and fastest method for getting started with the Backstage Showcase a
          apps:
            - $include: github-app-backstage-showcase-credentials.local.yaml
 
+   techdocs:
+     builder: 'local' # Alternatives - 'external'
+     generator:
+       runIn: 'local' # Alternatives - 'local'
+     publisher:
+       type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+
    auth:
      environment: development
      providers:


### PR DESCRIPTION
## Description

Second half of the Techdocs PR. This PR adds the GitHub actions to build and publish the Techdocs to the OBC that was created in the [previous PR](https://github.com/janus-idp/backstage-showcase/pull/117). Also adds the ability to pull in the the documentation from the OBC by updating the app-config to point to the bucket. 

## Which issue(s) does this PR fix

- Fixes #58 

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
