### PR TITLE
Revert "enabled default github identity resolver"

### DIFF
--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -37,7 +37,16 @@ export default async function createPlugin(
       //   https://backstage.io/docs/auth/identity-resolver
       github: providers.github.create({
         signIn: {
-          resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+          resolver(_, ctx) {
+            const userRef = 'user:default/guest'; // Must be a full entity reference
+            return ctx.issueToken({
+              claims: {
+                sub: userRef, // The user's own identity
+                ent: [userRef], // A list of identities that the user claims ownership through
+              },
+            });
+          },
+          // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),
     },


### PR DESCRIPTION
Reverts janus-idp/backstage-showcase#121

As it was breaking the GitHub authentication and many plugins are not working anymore.