### PR TITLE
Apply patch to Keycloak service

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -16,3 +16,13 @@ commonLabels:
 images:
   - name: backstage-showcase
     newName: quay.io/janus-idp/backstage-showcase
+patchesJson6902:
+  - patch: |-
+      - op: remove
+        path: /spec/selector/app.kubernetes.io~1name
+      - op: remove
+        path: /spec/selector/app.kubernetes.io~1instance
+    target:
+      kind: Service
+      version: v1
+      name: keycloak


### PR DESCRIPTION
## Description

Applies the patchesJson6902 to remove some labels in the labelSelector field. Currently, the labels defined within kustomize.yaml are being added to the labelSelector field in the Keycloak service. This is leading to the Keycloak deploymentconfig not being able to pick up the service.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
Will need this merged before the Keycloak auth PR is merged. The Keycloak auth PR will need information from Keycloak.