### PR TITLE
Keycloak auth

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -27,3 +27,19 @@ backend:
       ssl:
         ca: # if you have a CA file and want to verify it you can uncomment this section
           $file: /mnt/certs/ca.crt
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  environment: production
+  providers:
+    github:
+      development:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+    oauth2Proxy: {}
+
+catalog:
+  # Overrides the default list locations from app-config.yaml as these contain example data.
+  # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
+  # on how to get entities into the catalog.
+  locations: []

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -90,7 +90,7 @@ techdocs:
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
-  environment: development
+  environment: production
   providers:
     github:
       development:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -90,7 +90,7 @@ techdocs:
 
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
-  environment: production
+  environment: development
   providers:
     github:
       development:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -96,6 +96,7 @@ auth:
       development:
         clientId: ${AUTH_GITHUB_CLIENT_ID}
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+    oauth2Proxy: {}
 
 scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -62,6 +62,28 @@ spec:
             periodSeconds: 30
             successThreshold: 1
             failureThreshold: 3
+        - resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 400m
+          name: oauth2-proxy
+          envFrom:
+            - secretRef:
+                name: janus-idp
+          ports:
+            - name: oauth2-proxy
+              containerPort: 4180
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          image: 'quay.io/oauth2-proxy/oauth2-proxy:latest'
+          args:
+            - '--provider=oidc'
+            - '--email-domain=*'
+            - '--upstream=http://localhost:7007'
+            - '--http-address=0.0.0.0:4180'
+            - '--skip-provider-button'
       volumes:
         - name: ca-cert
           secret:

--- a/manifests/base/ingress.yaml
+++ b/manifests/base/ingress.yaml
@@ -22,7 +22,7 @@ spec:
               service:
                 name: backstage
                 port:
-                  number: 7007
+                  number: 4180
     - host: showcase.janus-idp.io
       http:
         paths:
@@ -32,4 +32,4 @@ spec:
               service:
                 name: backstage
                 port:
-                  number: 7007
+                  number: 4180

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -11,8 +11,8 @@ spec:
   sessionAffinity: None
   ports:
     - name: http-backend
-      port: 7007
-      targetPort: backend
+      port: 4180
+      targetPort: oauth2-proxy
       protocol: TCP
   selector:
     app.kubernetes.io/component: backstage

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -14,6 +14,7 @@ describe('App', () => {
             techdocs: {
               storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
             },
+            auth: { environment: 'development' },
           },
           context: 'test',
         },

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -31,6 +31,7 @@ import {
   AlertDisplay,
   OAuthRequestDialog,
   ProxiedSignInPage,
+  SignInPage,
 } from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
@@ -43,6 +44,11 @@ import { HomePage } from './components/home/HomePage';
 import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { OcmPage } from '@janus-idp/backstage-plugin-ocm';
 import Logo from './components/Root/LogoIcon';
+import {
+  configApiRef,
+  githubAuthApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
 
 const app = createApp({
   apis,
@@ -62,9 +68,28 @@ const app = createApp({
     });
   },
   components: {
-    SignInPage: props => (
-      <ProxiedSignInPage {...props} provider="oauth2Proxy" />
-    ),
+    SignInPage: props => {
+      const configApi = useApi(configApiRef);
+      if (configApi.getString('auth.environment') === 'development') {
+        return (
+          <SignInPage
+            {...props}
+            title="Select a sign-in method"
+            align="center"
+            providers={[
+              'guest',
+              {
+                id: 'github-auth-provider',
+                title: 'GitHub',
+                message: 'Sign in using GitHub',
+                apiRef: githubAuthApiRef,
+              },
+            ]}
+          />
+        );
+      }
+      return <ProxiedSignInPage {...props} provider="oauth2Proxy" />;
+    },
   },
   themes: [
     {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,7 +27,11 @@ import { entityPage } from './components/catalog/EntityPage';
 import { searchPage } from './components/search/SearchPage';
 import { Root } from './components/Root';
 
-import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
+import {
+  AlertDisplay,
+  OAuthRequestDialog,
+  ProxiedSignInPage,
+} from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
@@ -56,6 +60,11 @@ const app = createApp({
     bind(orgPlugin.externalRoutes, {
       catalogIndex: catalogPlugin.routes.catalogIndex,
     });
+  },
+  components: {
+    SignInPage: props => (
+      <ProxiedSignInPage {...props} provider="oauth2Proxy" />
+    ),
   },
   themes: [
     {

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -5,6 +5,10 @@ import {
 } from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
+import {
+  DEFAULT_NAMESPACE,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -47,6 +51,37 @@ export default async function createPlugin(
             });
           },
           // resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
+        },
+      }),
+      oauth2Proxy: providers.oauth2Proxy.create({
+        signIn: {
+          async resolver({ result }, ctx) {
+            const name = result.getHeader('x-forwarded-preferred-username');
+            if (!name) {
+              throw new Error('Request did not contain a user');
+            }
+
+            try {
+              const signedInUser = await ctx.signInWithCatalogUser({
+                entityRef: { name },
+              });
+
+              return Promise.resolve(signedInUser);
+            } catch (e) {
+              const userEntityRef = stringifyEntityRef({
+                kind: 'User',
+                name: name,
+                namespace: DEFAULT_NAMESPACE,
+              });
+
+              return ctx.issueToken({
+                claims: {
+                  sub: userEntityRef,
+                  ent: [userEntityRef],
+                },
+              });
+            }
+          },
         },
       }),
     },


### PR DESCRIPTION
## Description

Adds Keycloak Authentication to the showcase app. Will also deploy an OAuth2 Proxy sidecar container. Also includes the ability to switch from the `ProxiedSignInPage` to the `SignInPage` whenever the `auth.environment` is set to development. This means that a developer will not need to have Keycloak and Oauth2 Proxy set up to be able to run the app locally.

## Which issue(s) does this PR fix

- Fixes #107 

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
This will require PR #149 and the logout issue from upstream to be handled before we can merge this PR. The logout issue involves not being able to logout in Backstage whenever you are using an OAuth2 Proxy.