### PR TITLE
feat: Add postgres database to deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ COPY --from=build /opt/app-root/src/packages/backend/dist/bundle.tar.gz .
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 # Copy any other files that we need at runtime
-COPY ./app-config.yaml .
-COPY ./github-app-backstage-showcase-credentials.yaml .
+COPY ./app-config.yaml ./app-config.production.yaml ./
+COPY ./github-app-backstage-showcase-credentials.yaml ./
 COPY ./catalog-entities ./catalog-entities
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -11,25 +11,19 @@ backend:
   baseUrl: http://localhost:7007
   # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
   # all interfaces, the most permissive setting. The right value depends on your specific deployment.
-  listen: ':7007'
+  listen: ":7007"
 
   # config options: https://node-postgres.com/api/client
   database:
     client: pg
     connection:
-      host: ${POSTGRES_HOST}
-      port: ${POSTGRES_PORT}
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
+      host: ${host}
+      port: ${port}
+      user: ${user}
+      password: ${password}
       # https://node-postgres.com/features/ssl
       # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
       # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
-      # ssl:
-      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-      #     $file: <file-path>/ca/server.crt
-
-catalog:
-  # Overrides the default list locations from app-config.yaml as these contain example data.
-  # See https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog for more details
-  # on how to get entities into the catalog.
-  locations: []
+      ssl:
+        ca: # if you have a CA file and want to verify it you can uncomment this section
+          $file: /mnt/certs/ca.crt

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: backstage
   namespace: "janus-idp"
-  labels: 
+  labels:
     app.kubernetes.io/component: backstage
     backstage.io/kubernetes-id: janus-idp
 spec:
@@ -32,13 +32,22 @@ spec:
           command:
             - node
             - packages/backend
+            - --config
+            - app-config.yaml
+            - --config
+            - app-config.production.yaml
           envFrom:
             - secretRef:
                 name: janus-idp
+            - secretRef:
+                name: janus-idp-pguser-janus-idp
             - configMapRef:
                 name: backstage-showcase-bucket-claim
             - secretRef:
                 name: backstage-showcase-bucket-claim
+          volumeMounts:
+            - name: ca-cert
+              mountPath: "/mnt/certs"
           ports:
             - name: backend
               containerPort: 7007
@@ -53,3 +62,10 @@ spec:
             periodSeconds: 30
             successThreshold: 1
             failureThreshold: 3
+      volumes:
+        - name: ca-cert
+          secret:
+            secretName: janus-idp-cluster-cert
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: janus-idp
-resources: 
+components:
+  - ../components/postgres-db
+resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
@@ -10,9 +12,10 @@ resources:
   - certificate.yaml
   - keycloak
   - obc.yaml
+  - postgres.yaml
 commonLabels:
-    app.kubernetes.io/name: backstage
-    app.kubernetes.io/instance: backstage
+  app.kubernetes.io/name: backstage
+  app.kubernetes.io/instance: backstage
 images:
   - name: backstage-showcase
     newName: quay.io/janus-idp/backstage-showcase

--- a/manifests/base/postgres.yaml
+++ b/manifests/base/postgres.yaml
@@ -1,0 +1,50 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: janus-idp
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 2Gi
+      resources:
+        limits:
+          cpu: 300m
+        requests:
+          cpu: 200m
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+      global:
+        # Save backups for 7 days, this means 1 full backups with 6 differential ones in between
+        repo1-retention-full: "1"
+        repo1-retention-full-type: count
+      repoHost:
+        resources:
+          limits:
+            cpu: 300m
+          requests:
+            cpu: 200m
+      repos:
+        - name: repo1
+          schedules:
+            # Every sunday at 01:00 full backup
+            full: "0 1 * * 0"
+            # Monday through saturday at 01:00 differential backup
+            differential: "0 1 * * 1-6"
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: 2Gi
+  users:
+    - name: janus-idp
+      options: "SUPERUSER"

--- a/manifests/components/postgres-db/kustomization.yaml
+++ b/manifests/components/postgres-db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - operator-group.yaml
+  - sub.yaml

--- a/manifests/components/postgres-db/operator-group.yaml
+++ b/manifests/components/postgres-db/operator-group.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: crunchy-postgres-group
+spec:
+  targetNamespaces:
+  - janus-idp

--- a/manifests/components/postgres-db/sub.yaml
+++ b/manifests/components/postgres-db/sub.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: crunchy-postgres-sub
+spec:
+  channel: v5
+  name: crunchy-postgres-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Description

Add a deployment for a postgres database which includes:
- a postgres `component` for adding the operator
- a `PostgresCluster` which is the actual database instance
- the database will automatically backup to a storage volume every week with a full backup and every 6 days with a differential backup

## Which issue(s) does this PR fix

- Fixes #141

## PR acceptance criteria

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
