### PR TITLE
feat: Update Janus Showcase data

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -109,51 +109,13 @@ catalog:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
-    - allow: [Component, System, API, Resource, Location, Template]
+    - allow: [Component, System, Group, Resource, Location, Template]
   locations:
-    # File locations are relative to the backend process, typically `packages/backend`
-
-    # Local components
     - type: file
-      target: ../../catalog-entities/components.yaml
-      rules:
-        - allow: [Component]
-
-    # Local organizational data
-    - type: file
-      target: ../../catalog-entities/org.yaml
-      rules:
-        - allow: [User, Group]
-
-    # Local systems
-    - type: file
-      target: ../../catalog-entities/systems.yaml
-      rules:
-        - allow: [System]
-
-    # For when building the image with Docker
-    # Local components
-    - type: file
-      target: ./catalog-entities/components.yaml
-      rules:
-        - allow: [Component]
-
-    # Local organizational data
-    - type: file
-      target: ./catalog-entities/org.yaml
-      rules:
-        - allow: [User, Group]
-
-    # Local systems
-    - type: file
-      target: ./catalog-entities/systems.yaml
-      rules:
-        - allow: [System]
+      target: ../../catalog-entities/all.yaml
 
     - type: url
       target: https://github.com/janus-idp/software-templates/blob/main/showcase-templates.yaml
-      rules:
-        - allow: [Template]
 
   providers:
     keycloakOrg:

--- a/catalog-entities/all.yaml
+++ b/catalog-entities/all.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: entities
+  description: A collection of all the catalog entities
+spec:
+  targets:
+    - ./components.yaml
+    - ./groups.yaml
+    - ./systems.yaml
+    - ./resources.yaml
+

--- a/catalog-entities/components.yaml
+++ b/catalog-entities/components.yaml
@@ -1,24 +1,8 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Location
 metadata:
-  name: backstage-showcase
-  description: |
-    This is the Janus Community Showcase of Backstage.io
-  links:
-    - title: Janus Website
-      url: https://janus-idp.io
-    - title: Janus Showcase
-      url: https://janus-idp.apps.smaug.na.operate-first.cloud/
-  annotations:
-    argocd/app-name: "janus-idp-smaug"
-    backstage.io/kubernetes-id: "janus-idp"
-    backstage.io/kubernetes-namespace: janus-idp
-    backstage.io/techdocs-ref: url:https://github.com/janus-idp/backstage-showcase
-    github.com/project-slug: janus-idp/backstage-showcase
-    quay.io/repository-slug: janus-idp/backstage-showcase
-    sonarqube.org/project-key: janus-idp_backstage-showcase
+  name: components
+  description: A collection of all components
 spec:
-  type: website
-  system: examples
-  owner: janus-authors
-  lifecycle: production
+  targets:
+    - ./components/showcase.yaml

--- a/catalog-entities/components/showcase.yaml
+++ b/catalog-entities/components/showcase.yaml
@@ -2,11 +2,14 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: backstage-showcase
+  title: Backstage Showcase
   description: |
     This is the Janus Community Showcase of Backstage.io
   links:
-    - title: Website
+    - title: Janus Website
       url: https://janus-idp.io
+    - title: Janus Showcase
+      url: https://janus-idp.apps.smaug.na.operate-first.cloud/
     - title: Blog
       url: https://janus-idp.io/blog
     - title: Slack
@@ -16,9 +19,17 @@ metadata:
     backstage.io/kubernetes-id: "janus-idp"
     github.com/project-slug: janus-idp/backstage-showcase
     quay.io/repository-slug: janus-idp/backstage-showcase
-    backstage.io/techdocs-ref: dir:.
+    backstage.io/techdocs-ref: url:https://github.com/janus-idp/backstage-showcase
     backstage.io/kubernetes-namespace: janus-idp
+    sonarqube.org/project-key: janus-idp_backstage-showcase
 spec:
   type: website
+  system: janus-idp
   owner: janus-authors
   lifecycle: production
+  dependsOn:
+    - resource:pgdb
+    - resource:argocd
+    - resource:obc
+    - resource:keycloak
+    - resource:github

--- a/catalog-entities/groups.yaml
+++ b/catalog-entities/groups.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: groups
+  description: A collection of all groups
+spec:
+  targets:
+    - ./groups/janus-authors.yaml

--- a/catalog-entities/groups/janus-authors.yaml
+++ b/catalog-entities/groups/janus-authors.yaml
@@ -4,6 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
   name: janus-authors
+  title: Janus-IDP Authors
 spec:
   type: team
   children: []

--- a/catalog-entities/resources.yaml
+++ b/catalog-entities/resources.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: resources
+  description: A collection of all resources
+spec:
+  targets:
+    - ./resources/pgdb.yaml
+    - ./resources/argocd.yaml
+    - ./resources/obc.yaml
+    - ./resources/keycloak.yaml
+    - ./resources/github.yaml

--- a/catalog-entities/resources/argocd.yaml
+++ b/catalog-entities/resources/argocd.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: argocd
+  title: ArgoCD
+  description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes. We use ArgoCD for the deployment of this showcase.
+  links:
+    - url: https://argocd.operate-first.cloud/
+      title: Instance of ArgoCD
+      icon: web
+    - url: https://argo-cd.readthedocs.io/en/stable/
+      title: Documentation
+      icon: web
+      
+spec:
+  type: identity-provider
+  lifecycle: production
+  owner: janus-authors
+  system: janus-idp

--- a/catalog-entities/resources/github.yaml
+++ b/catalog-entities/resources/github.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: github
+  title: GitHub Showcase repository
+  description: We store our deployment manifests and code for the janus showcase in this GitHub repository.
+  links:
+    - url: https://github.com/janus-idp/backstage-showcase
+      title: GitHub Repository
+      icon: web
+spec:
+  type: repository
+  lifecycle: production
+  owner: janus-authors
+  system: janus-idp

--- a/catalog-entities/resources/keycloak.yaml
+++ b/catalog-entities/resources/keycloak.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: keycloak
+  title: KeyCloak
+  description: Keycloak is an open source software product to allow single sign-on with identity and access management aimed at modern applications and services. We use keycloack in this showcase.
+  links:
+    - url: https://www.keycloak.org/documentation
+      title: Documentation
+      icon: web
+spec:
+  type: identity-provider
+  lifecycle: production
+  owner: janus-authors
+  system: janus-idp

--- a/catalog-entities/resources/obc.yaml
+++ b/catalog-entities/resources/obc.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: obc
+  title: S3 Object bucket storage
+  description: Amazon Simple Storage Service used for storing our built techdocs.
+  links:
+    - url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html
+      title: Documentation
+      icon: web
+spec:
+  type: s3-bucket
+  lifecycle: production
+  owner: janus-authors
+  system: janus-idp

--- a/catalog-entities/resources/pgdb.yaml
+++ b/catalog-entities/resources/pgdb.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: pgdb
+  title: PostgreSQL cluster
+  description: PostgreSQL is a powerful, open source object-relational database system. PostgreSQL cluster is created by Crunchy Postgres for Kubernetes operator. We use Postgres as the databse for this showcase.
+  links:
+    - url: https://www.crunchydata.com/products/crunchy-high-availability-postgresql
+      title: Crunchy product pages
+      icon: web
+    - url: https://access.crunchydata.com/documentation/postgres-operator/v5/
+      title: Documentation
+      icon: web
+spec:
+  type: database
+  lifecycle: production
+  owner: janus-authors
+  system: janus-idp

--- a/catalog-entities/systems.yaml
+++ b/catalog-entities/systems.yaml
@@ -1,8 +1,8 @@
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system
 apiVersion: backstage.io/v1alpha1
-kind: System
+kind: Location
 metadata:
-  name: examples
+  name: systems
+  description: A collection of all systems
 spec:
-  owner: janus-authors
+  targets:
+    - ./systems/janus-idp.yaml

--- a/catalog-entities/systems/janus-idp.yaml
+++ b/catalog-entities/systems/janus-idp.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: janus-idp
+  title: Janus-IDP
+spec:
+  owner: janus-authors


### PR DESCRIPTION
## Description

Update the Janus Showcase data by adding:
- Individual locations for all kinds 
- A single `all` location to aggregate all other locations
- Remove `catalog-info.yaml` file since it was a duplicate of the component `showcase`
- Add resources for `argocd`, `obc`, `postgres db`, `keycloak` and `github`
- Add all of the resources as the dependencies for the `showcase` component
- Create `janus-idp` system that contains all of the resources, components and groups

## Which issue(s) does this PR fix

- Fixes #143

## PR acceptance criteria

_Put an `x` in the boxes that apply_

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary

## How to test changes / Special notes to the reviewer
I wasn't sure what was meant by the resource `gitops repo` so I didn't add that one. If you could elaborate on what you meant by that @christophe-f, I can add also add that one as an additional resource.
