### PR TITLE
Showcase data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,6 @@ RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 # Copy any other files that we need at runtime
 COPY ./app-config.yaml .
 COPY ./github-app-backstage-showcase-credentials.yaml .
-COPY ./catalog-entities ./catalog-entities
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -107,8 +107,8 @@ catalog:
   rules:
     - allow: [Component, System, Group, Resource, Location, Template]
   locations:
-    - type: file
-      target: ../../catalog-entities/all.yaml
+    - type: url
+      target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
 
     - type: url
       target: https://github.com/janus-idp/software-templates/blob/main/showcase-templates.yaml


### PR DESCRIPTION
## Description

Adds a URL pointing to the `all.yaml` within our catalog entities directory for the catalog. This will fix the of the data not showing up within the catalog. 

The issue is happening because we currently have to account for whether the Showcase app is running in a container or locally. This requires us to declare the location twice whenever we point to a local directory. The first declaration is if the app is running locally `./catalog-entities/` and the second is whenever it is running in a container `../../catalog-entities/`

## Which issue(s) does this PR fix

- Fixes #178

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
