### PR TITLE
Add postgres database manifests files

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: backstage
   namespace: "janus-idp"
-  labels: 
+  labels:
     app.kubernetes.io/component: backstage
     backstage.io/kubernetes-id: janus-idp
 spec:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: janus-idp
-resources: 
+components:
+  - ../components/postgres-db
+resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
@@ -10,9 +12,10 @@ resources:
   - certificate.yaml
   - keycloak
   - obc.yaml
+  - postgres.yaml
 commonLabels:
-    app.kubernetes.io/name: backstage
-    app.kubernetes.io/instance: backstage
+  app.kubernetes.io/name: backstage
+  app.kubernetes.io/instance: backstage
 images:
   - name: backstage-showcase
     newName: quay.io/janus-idp/backstage-showcase

--- a/manifests/base/postgres.yaml
+++ b/manifests/base/postgres.yaml
@@ -1,0 +1,50 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: janus-idp
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.2-1
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 2Gi
+      resources:
+        limits:
+          cpu: 300m
+        requests:
+          cpu: 200m
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
+      global:
+        # Save backups for 7 days, this means 1 full backups with 6 differential ones in between
+        repo1-retention-full: "1"
+        repo1-retention-full-type: count
+      repoHost:
+        resources:
+          limits:
+            cpu: 300m
+          requests:
+            cpu: 200m
+      repos:
+        - name: repo1
+          schedules:
+            # Every sunday at 01:00 full backup
+            full: "0 1 * * 0"
+            # Monday through saturday at 01:00 differential backup
+            differential: "0 1 * * 1-6"
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: 2Gi
+  users:
+    - name: janus-idp
+      options: "SUPERUSER"

--- a/manifests/components/postgres-db/kustomization.yaml
+++ b/manifests/components/postgres-db/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - operator-group.yaml
+  - sub.yaml

--- a/manifests/components/postgres-db/operator-group.yaml
+++ b/manifests/components/postgres-db/operator-group.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: crunchy-postgres-group
+spec:
+  targetNamespaces:
+  - janus-idp

--- a/manifests/components/postgres-db/sub.yaml
+++ b/manifests/components/postgres-db/sub.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: crunchy-postgres-sub
+spec:
+  channel: v5
+  name: crunchy-postgres-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Description

Adds the manifest files to deploy a postgres database in our OpenShift namespace. This is the first step in adding the postgres database to the backstage showcase.

We had some issues with deployment to the OpenShift cluster when we merged #157. So now we are going to try doing this in steps to see if we can get it to work. 

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
