### PR TITLE
fix: update slack invite link

### DIFF
--- a/catalog-entities/components/showcase.yaml
+++ b/catalog-entities/components/showcase.yaml
@@ -13,7 +13,7 @@ metadata:
     - title: Blog
       url: https://janus-idp.io/blog
     - title: Slack
-      url: https://join.slack.com/t/janus-idp/shared_invite/zt-1nii16o6e-SGscZ4YtAktL6rRtZZBUfA
+      url: https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg
   annotations:
     argocd/app-name: "janus-idp-smaug"
     backstage.io/kubernetes-id: "janus-idp"

--- a/packages/app/public/homepage/data.json
+++ b/packages/app/public/homepage/data.json
@@ -21,7 +21,7 @@
       {
         "iconUrl": "/homepage/icons/icons8/slack-new.png",
         "label": "Slack",
-        "url": "https://janus-idp.slack.com/join/shared_invite/zt-1nii16o6e-SGscZ4YtAktL6rRtZZBUfA#/shared-invite/email"
+        "url": "https://join.slack.com/t/janus-idp/shared_invite/zt-1pxtehxom-fCFtF9rRe3vFqUiFFeAkmg"
       },
       {
         "iconUrl": "/homepage/icons/icons8/youtube-play.png",


### PR DESCRIPTION
## Description

We've been notified via email that https://showcase.janus-idp.io/ is using an expired Slack invite link. This PR changes it to the same invite used in https://janus-idp.io (or `README.md` in this repo).

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

N/A

## How to test changes / Special notes to the reviewer

N/A