### PR TITLE
chore: Bump ocm plugins to the latest version

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -122,6 +122,13 @@ catalog:
         clientId: ${KEYCLOAK_CLIENT_ID}
         clientSecret: ${KEYCLOAK_CLIENT_SECRET}
 
+    ocm:
+      operate-first:
+        name: ${OCM_HUB_NAME}
+        url: ${OCM_HUB_URL}
+        serviceAccountToken: ${moc_infra_token}
+        owner: janus-authors
+
 kubernetes:
   serviceLocatorMethod:
     type: 'multiTenant'
@@ -133,12 +140,6 @@ kubernetes:
           authProvider: 'serviceAccount'
           skipTLSVerify: true
           serviceAccountToken: ${K8S_CLUSTER_TOKEN}
-
-ocm:
-  hub:
-    name: ${OCM_HUB_NAME}
-    url: ${OCM_HUB_URL}
-    serviceAccountToken: ${moc_infra_token}
 
 argocd:
   username: ${ARGOCD_USERNAME}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,7 +43,7 @@
     "@backstage/plugin-techdocs-react": "^1.1.4",
     "@backstage/plugin-user-settings": "^0.7.1",
     "@backstage/theme": "^0.2.18",
-    "@janus-idp/backstage-plugin-ocm": "^1.2.0",
+    "@janus-idp/backstage-plugin-ocm": "^2.1.0",
     "@janus-idp/backstage-plugin-quay": "^1.1.1",
     "@janus-idp/backstage-plugin-topology": "^1.2.5",
     "@material-ui/core": "^4.12.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,7 +37,7 @@
     "@backstage/plugin-search-backend-node": "^1.1.4",
     "@backstage/plugin-techdocs-backend": "^1.6.0",
     "@janus-idp/backstage-plugin-keycloak-backend": "^1.0.4",
-    "@janus-idp/backstage-plugin-ocm-backend": "^1.4.1",
+    "@janus-idp/backstage-plugin-ocm-backend": "^2.1.0",
     "@roadiehq/backstage-plugin-argo-cd-backend": "^2.7.1",
     "@roadiehq/scaffolder-backend-argocd": "^1.1.5",
     "app": "link:../app",

--- a/showcase-docs/getting-started.md
+++ b/showcase-docs/getting-started.md
@@ -86,6 +86,13 @@ The easiest and fastest method for getting started with the Backstage Showcase a
              realm: ${KEYCLOAK_REALM}
              clientId: ${KEYCLOAK_CLIENT_ID}
              clientSecret: ${KEYCLOAK_CLIENT_SECRET}
+       providers:
+         ocm:
+           hub:
+             name: ${OCM_HUB_NAME}
+             url: ${OCM_HUB_URL}
+             serviceAccountToken: ${moc_infra_token}
+             owner: # Existing catalog entity (User or Group) as the owner of the discovered clusters
 
      kubernetes:
        serviceLocatorMethod:
@@ -99,11 +106,7 @@ The easiest and fastest method for getting started with the Backstage Showcase a
                skipTLSVerify: true
                serviceAccountToken: ${K8S_CLUSTER_TOKEN}
 
-     ocm:
-       hub:
-         name: ${OCM_HUB_NAME}
-         url: ${OCM_HUB_URL}
-         serviceAccountToken: ${moc_infra_token}
+
 
      argocd:
        username: ${ARGOCD_USERNAME}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5542,16 +5542,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@janus-idp/backstage-plugin-ocm-backend@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@janus-idp/backstage-plugin-ocm-backend@npm:1.4.1"
+"@janus-idp/backstage-plugin-ocm-backend@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@janus-idp/backstage-plugin-ocm-backend@npm:2.1.0"
   dependencies:
     "@backstage/backend-common": ^0.18.1
     "@backstage/catalog-client": ^1.3.0
     "@backstage/catalog-model": ^1.1.5
     "@backstage/config": ^1.0.6
     "@backstage/plugin-catalog-node": ^1.3.2
-    "@janus-idp/backstage-plugin-ocm-common": 1.2.1
+    "@janus-idp/backstage-plugin-ocm-common": 2.0.0
     "@kubernetes/client-node": ^0.18.0
     express: ^4.17.1
     express-promise-router: ^4.1.0
@@ -5559,20 +5559,20 @@ __metadata:
     semver: ^7.3.8
     winston: ^3.2.1
     yn: ^5.0.0
-  checksum: 17228fcf60a7d65d08f2394ebb82ce2163dac2b684f9011fa3eec4c0db5b7c83e2fc4a92f791115b127f6530aa3fff8a5361abca8ae5421bd07c125c803e901e
+  checksum: 5685965178c00e4dd9309bc5ce789a96973ca678b294d76b7c7c0e337e2f59c6523e2583830c837c8bdd09a3ac9e57146f038fba5b9923f3c9d995031f0ac986
   languageName: node
   linkType: hard
 
-"@janus-idp/backstage-plugin-ocm-common@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@janus-idp/backstage-plugin-ocm-common@npm:1.2.1"
-  checksum: e69d94e54b6c8a98a88eff4cff3d13720b0c2098025b7654837c9aba664aefb2c57e8d0739c4471b91c32680915e5178cd51ec3197b8495891f492127b053fe3
+"@janus-idp/backstage-plugin-ocm-common@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@janus-idp/backstage-plugin-ocm-common@npm:2.0.0"
+  checksum: 8dd35ebde3faf2d65ceb4fffcb96e162cb168eec2b033cc3f49c7b542fdeb6e0367cc7d8aea844003d31835585b2c2be2744291a2aab1d178c387acd23b8fe5e
   languageName: node
   linkType: hard
 
-"@janus-idp/backstage-plugin-ocm@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@janus-idp/backstage-plugin-ocm@npm:1.2.0"
+"@janus-idp/backstage-plugin-ocm@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@janus-idp/backstage-plugin-ocm@npm:2.1.0"
   dependencies:
     "@backstage/catalog-model": ^1.1.5
     "@backstage/core-components": ^0.12.3
@@ -5582,14 +5582,14 @@ __metadata:
     "@backstage/plugin-home": ^0.4.30
     "@backstage/plugin-search-react": ^1.4.0
     "@backstage/theme": ^0.2.16
-    "@janus-idp/backstage-plugin-ocm-common": 1.2.1
+    "@janus-idp/backstage-plugin-ocm-common": 2.0.0
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.45
     react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0
-  checksum: c14dafc604b68ce2e5b35b643902cd169cc5e8733ad94a8d82a606567c375b727edde0215f464f17241639e45a6189b95d91821f2fe816900b9caa8b83d3899c
+  checksum: 2cb859794a61d91af2ebbecd8cc8b714b91d41921f42315e6d46c2bff935f415c237bbbd351efdd2ffbfb05bab018428ec068586920d162cffee0c6506b32e15
   languageName: node
   linkType: hard
 
@@ -10397,7 +10397,7 @@ __metadata:
     "@backstage/plugin-user-settings": ^0.7.1
     "@backstage/test-utils": ^1.2.6
     "@backstage/theme": ^0.2.18
-    "@janus-idp/backstage-plugin-ocm": ^1.2.0
+    "@janus-idp/backstage-plugin-ocm": ^2.1.0
     "@janus-idp/backstage-plugin-quay": ^1.1.1
     "@janus-idp/backstage-plugin-topology": ^1.2.5
     "@material-ui/core": ^4.12.2
@@ -11018,7 +11018,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": ^1.1.4
     "@backstage/plugin-techdocs-backend": ^1.6.0
     "@janus-idp/backstage-plugin-keycloak-backend": ^1.0.4
-    "@janus-idp/backstage-plugin-ocm-backend": ^1.4.1
+    "@janus-idp/backstage-plugin-ocm-backend": ^2.1.0
     "@roadiehq/backstage-plugin-argo-cd-backend": ^2.7.1
     "@roadiehq/scaffolder-backend-argocd": ^1.1.5
     "@types/dockerode": ^3.3.0


### PR DESCRIPTION
## Description

Update the `ocm` plugins to the latest versions. This includes some breaking changes:
- The configuration schema for the plugin moved to the catalog providers
- An `owner` field was added which automatically adds an owner to the discovered clusters
- Multiple hub environments can now be specified

## Which issue(s) does this PR fix

- None

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
None