### PR TITLE
Add Jenkins plugin to Showcase

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -67,6 +67,11 @@ proxy:
     allowedMethods: ['GET']
     auth: ${SONARQUBE_TOKEN}
 
+  '/jenkins/api':
+    target: ${JENKINS_URL}
+    headers:
+      Authorization: ${JENKINS_TOKEN}
+
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs
 # and an external cloud storage when deploying TechDocs for production use-case.
@@ -161,6 +166,13 @@ sonarqube:
   baseUrl: ${SONARQUBE_URL}
   apiKey: ${SONARQUBE_TOKEN}
 
+jenkins:
+  instances:
+  - name: default
+    baseUrl: ${JENKINS_URL}
+    username: ${JENKINS_USERNAME}
+    apiKey: ${JENKINS_TOKEN}
+
 enabled:
   kubernetes: ${K8S_ENABLED}
   techdocs: ${TECHDOCS_ENABLED}
@@ -171,3 +183,4 @@ enabled:
   github: ${GITHUB_ENABLED}
   githubOrg: ${GITHUB_ORG_ENABLED}
   gitlab: ${GITLAB_ENABLED}
+  jenkins: ${JENKINS_ENABLED}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,6 +30,7 @@
     "@backstage/plugin-github-actions": "^0.5.17",
     "@backstage/plugin-github-issues": "^0.2.6",
     "@backstage/plugin-home": "^0.5.0",
+    "@backstage/plugin-jenkins": "^0.7.16",
     "@backstage/plugin-kubernetes": "^0.8.0",
     "@backstage/plugin-org": "^0.6.7",
     "@backstage/plugin-permission-react": "^0.4.12",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -22,11 +22,6 @@ import {
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
-import { apis } from './apis';
-import { entityPage } from './components/catalog/EntityPage';
-import { SearchPage } from './components/search/SearchPage';
-import { Root } from './components/Root';
-
 import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
@@ -34,12 +29,16 @@ import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
-import { janusTheme } from './themes/janus';
-import { HomePage } from './components/home/HomePage';
 import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { OcmPage } from '@janus-idp/backstage-plugin-ocm';
+import { apis } from './apis';
 import Logo from './components/Root/LogoIcon';
 import { LearningPaths } from './components/learningPaths/LearningPathsPage';
+import { entityPage } from './components/catalog/EntityPage';
+import { SearchPage } from './components/search/SearchPage';
+import { Root } from './components/Root';
+import { HomePage } from './components/home/HomePage';
+import { janusTheme } from './themes/janus';
 
 const app = createApp({
   apis,

--- a/packages/app/src/components/catalog/EntityPage/Content/Overview.tsx
+++ b/packages/app/src/components/catalog/EntityPage/Content/Overview.tsx
@@ -29,6 +29,10 @@ import {
 } from '@roadiehq/backstage-plugin-security-insights';
 import { isCIsAvailable } from './CI';
 import { entityWarningContent } from './EntityWarning';
+import {
+  isJenkinsAvailable,
+  EntityLatestJenkinsRunCard,
+} from '@backstage/plugin-jenkins';
 
 export const overviewContent = (
   <Grid container spacing={3} justifyContent="space-evenly">
@@ -179,6 +183,14 @@ export const overviewContent = (
       <EntitySwitch.Case if={isCIsAvailable}>
         <Grid item xs={12}>
           <EntityArgoCDOverviewCard />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+
+    <EntitySwitch>
+      <EntitySwitch.Case if={isJenkinsAvailable}>
+        <Grid item xs={12}>
+          <EntityLatestJenkinsRunCard branch="main,master" />
         </Grid>
       </EntitySwitch.Case>
     </EntitySwitch>

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,7 @@
     "@backstage/plugin-catalog-backend": "^1.9.0",
     "@backstage/plugin-catalog-backend-module-github": "^0.2.7",
     "@backstage/plugin-catalog-backend-module-openapi": "^0.1.10",
+    "@backstage/plugin-jenkins-backend": "^0.1.34",
     "@backstage/plugin-kubernetes-backend": "^0.10.0",
     "@backstage/plugin-permission-common": "^0.7.5",
     "@backstage/plugin-permission-node": "^0.7.7",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,6 +28,7 @@ import argocd from './plugins/argocd';
 import auth from './plugins/auth';
 import catalog from './plugins/catalog';
 import gitlab from './plugins/gitlab';
+import jenkins from './plugins/jenkins';
 import kubernetes from './plugins/kubernetes';
 import ocm from './plugins/ocm';
 import proxy from './plugins/proxy';
@@ -181,6 +182,14 @@ async function main() {
     apiRouter,
     createEnv,
     router: gitlab,
+    isOptional: true,
+  });
+  await addPlugin({
+    plugin: 'jenkins',
+    config,
+    apiRouter,
+    createEnv,
+    router: jenkins,
     isOptional: true,
   });
 

--- a/packages/backend/src/plugins/jenkins.ts
+++ b/packages/backend/src/plugins/jenkins.ts
@@ -1,0 +1,24 @@
+import {
+  createRouter,
+  DefaultJenkinsInfoProvider,
+} from '@backstage/plugin-jenkins-backend';
+import { CatalogClient } from '@backstage/catalog-client';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const catalog = new CatalogClient({
+    discoveryApi: env.discovery,
+  });
+
+  return await createRouter({
+    logger: env.logger,
+    jenkinsInfoProvider: DefaultJenkinsInfoProvider.fromConfig({
+      config: env.config,
+      catalog,
+    }),
+    permissions: env.permissions,
+  });
+}

--- a/showcase-docs/getting-started.md
+++ b/showcase-docs/getting-started.md
@@ -35,12 +35,18 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      ocm: ${OCM_ENABLED}
      github: ${GITHUB_ENABLED}
      githubOrg: ${GITHUB_ORG_ENABLED}
+     jenkins: ${JENKINS_ENABLED}
 
    proxy:
      '/sonarqube':
        target: ${SONARQUBE_URL}/api
        allowedMethods: ['GET']
        auth: ${SONARQUBE_TOKEN}
+
+     '/jenkins/api':
+       target: ${JENKINS_URL}
+       headers:
+         Authorization: ${JENKINS_TOKEN}
 
    sonarqube:
      baseUrl: ${SONARQUBE_URL}
@@ -131,6 +137,11 @@ The easiest and fastest method for getting started with the Backstage Showcase a
              - name: argoInstance2
                url: ${ARGOCD_INSTANCE2_URL}
                token: ${ARGOCD_AUTH_TOKEN2}
+
+     jenkins:
+       baseUrl: ${JENKINS_URL}
+       username: ${JENKINS_USERNAME}
+       apiKey: ${JENKINS_TOKEN}
    ```
 
    - Enable plugins
@@ -144,6 +155,7 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      - `${GITHUB_ENABLED}` Set to `true` to enable the GitHub Entity backend plugin. Default is `false`
      - `${GITHUB_ORG_ENABLED}` Set to `true` to enable the GitHub Org Entity backend plugin. Default is `false`
      - `${GITLAB_ENABLED}` Set to `true` to enable the GitLab Entity backend plugin. Default is `false`
+     - `${JENKINS_ENABLED}` Set to `true` to enable the Jenkins Entity backend plugin. Default is `false`
 
    - Setup a GitHub app (Needed for the GitHub Issues, GitHub Pull Request plugins) and replace the variables
 
@@ -192,6 +204,7 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      - `${SONARQUBE_TOKEN}` a sonarqube [token](https://docs.sonarqube.org/9.8/user-guide/user-account/generating-and-using-tokens/) with enough permission to read all the SonaQube projects. Mandatory if plugin is enabled
 
    - Setup Techdocs with an external S3 bucket storage
+
      - `${TECHDOCS_BUILDER_TYPE}` Set to 'local' for simple setup, or 'external' to use a pipeline
      - `${TECHDOCS_GENERATOR_TYPE}` Set to 'local' for most of the use cases. You can use also 'docker'
      - `${TECHDOCS_PUBLISHER_TYPE}` Set to 'local' for simple setup, or 'awsS3' to use a S3 storage. 'googleGcs' is not supported at the moment.
@@ -200,6 +213,11 @@ The easiest and fastest method for getting started with the Backstage Showcase a
      - `${BUCKET_URL}` the bucket url
      - `${AWS_ACCESS_KEY_ID}` the AWS credentials Key Id
      - `${AWS_SECRET_ACCESS_KEY}` the AWS credentials Access Key
+
+   - Setup a Jenkins instance and then pass the following environment variables to backstage:
+     - `${JENKINS_URL}` with the URL where your Jenkins instance can be accessed
+     - `${JENKINS_USERNAME}` with the name of the user to be accessed through the API
+     - `${JENKINS_TOKEN}` with the API token to be used for the given user
 
 3. Run `yarn install` to install the dependencies
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,6 +3999,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-jenkins-backend@npm:^0.1.34":
+  version: 0.1.34
+  resolution: "@backstage/plugin-jenkins-backend@npm:0.1.34"
+  dependencies:
+    "@backstage/backend-common": ^0.18.4
+    "@backstage/catalog-client": ^1.4.1
+    "@backstage/catalog-model": ^1.3.0
+    "@backstage/config": ^1.0.7
+    "@backstage/errors": ^1.1.5
+    "@backstage/plugin-auth-node": ^0.2.13
+    "@backstage/plugin-jenkins-common": ^0.1.15
+    "@backstage/plugin-permission-common": ^0.7.5
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    jenkins: ^1.0.0
+    winston: ^3.2.1
+    yn: ^4.0.0
+  checksum: 85a1829330581fca158a6d1ed6029bfafe35f29bb236d5b88d300b6f58a24d49bdc1a5e49369bf6643f0c3d43467b1b2e6575562bd75bd0bc0020f7354ae0812
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-jenkins-common@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "@backstage/plugin-jenkins-common@npm:0.1.15"
+  dependencies:
+    "@backstage/plugin-catalog-common": ^1.0.13
+    "@backstage/plugin-permission-common": ^0.7.5
+  checksum: 56e56c8aebdbfa45c8f1fb73d3420d5fe2071149cafac458803f027e86ebe7ac0a3ee2434ca7d04b0fce09075865adf3e2bd8aca882f74ebfdf873ddf8133353
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-jenkins@npm:^0.7.16":
+  version: 0.7.16
+  resolution: "@backstage/plugin-jenkins@npm:0.7.16"
+  dependencies:
+    "@backstage/catalog-model": ^1.3.0
+    "@backstage/core-components": ^0.13.0
+    "@backstage/core-plugin-api": ^1.5.1
+    "@backstage/errors": ^1.1.5
+    "@backstage/plugin-catalog-react": ^1.5.0
+    "@backstage/plugin-jenkins-common": ^0.1.15
+    "@backstage/theme": ^0.2.19
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    luxon: ^3.0.0
+    react-use: ^17.2.4
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0
+    react-dom: ^16.13.1 || ^17.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: e2ac65c58fe1ad80aca989bf07c1e8526a0a005fd5247bc01da829cfa585af771e0765eb049fed495c891dd7500954453f790ecaed2b49d4399860a923791484
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-kubernetes-backend@npm:^0.10.0":
   version: 0.10.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.10.0"
@@ -10604,6 +10660,7 @@ __metadata:
     "@backstage/plugin-github-actions": ^0.5.17
     "@backstage/plugin-github-issues": ^0.2.6
     "@backstage/plugin-home": ^0.5.0
+    "@backstage/plugin-jenkins": ^0.7.16
     "@backstage/plugin-kubernetes": ^0.8.0
     "@backstage/plugin-org": ^0.6.7
     "@backstage/plugin-permission-react": ^0.4.12
@@ -11233,6 +11290,7 @@ __metadata:
     "@backstage/plugin-catalog-backend": ^1.9.0
     "@backstage/plugin-catalog-backend-module-github": ^0.2.7
     "@backstage/plugin-catalog-backend-module-openapi": ^0.1.10
+    "@backstage/plugin-jenkins-backend": ^0.1.34
     "@backstage/plugin-kubernetes-backend": ^0.10.0
     "@backstage/plugin-permission-common": ^0.7.5
     "@backstage/plugin-permission-node": ^0.7.7
@@ -17866,6 +17924,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jenkins@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "jenkins@npm:1.0.1"
+  dependencies:
+    papi: ^1.1.0
+  checksum: b57eab2e9bed834849bc5acf32cc3b1d5c1ed78c568a17db94f3081a72bb279a6ed889a2837688b380de0d8e6a78a537c0c3f90cdc132a721adc5892a8090d12
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^29.5.0":
   version: 29.5.0
   resolution: "jest-changed-files@npm:29.5.0"
@@ -21479,6 +21546,13 @@ __metadata:
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
   checksum: 1be2bfa1f807608c7538afa15d6f25baa523c30ec870a3228a89579e474a4d992f4293859524e46d5d87fd30fa17c5edf34dbef0671251d9749820b488660b16
+  languageName: node
+  linkType: hard
+
+"papi@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "papi@npm:1.1.2"
+  checksum: e1d1296478b184b4f0024b3e52149ecd486f32f2d81f1d59e910f7ae5c68276f81270a4e215c2611a939e0d994da17383d87a304e771f64ef7a9083f0d5456cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

## Description

This pull request adds the Jenkins plugin to 
the backstage showcase code. The user can 
configure their Jenkins instance via 
`app-config.yaml` by providing their:

- `JENKINS_URL`
- `JENKINS_USERNAME`
- `JENKINS_API_TOKEN`

The Jenkins plugin adds a history of runs to 
the CI/CD page and an overview of the jenkins 
entity to the overview page.

#### Overview tab:

![image](https://user-images.githubusercontent.com/97077423/234989242-c5e0b50b-704e-447d-9561-7b0524aa2ede.png)



#### CI/CD tab:
![image](https://user-images.githubusercontent.com/97077423/234982185-e4fa73a0-d2ac-4c95-b6c8-ac22fbc6fda4.png)



## Which issue(s) does this PR fix

Fixes #173

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
