### PR TITLE
add the annotation to enable tekton in the CI tab of Backstage Showcase entity

### DIFF
--- a/catalog-entities/components/showcase.yaml
+++ b/catalog-entities/components/showcase.yaml
@@ -19,6 +19,7 @@ metadata:
     backstage.io/kubernetes-id: "janus-idp"
     github.com/project-slug: janus-idp/backstage-showcase
     quay.io/repository-slug: janus-idp/backstage-showcase
+    janus-idp.io/tekton-enabled: 'true'
     backstage.io/techdocs-ref: url:https://github.com/janus-idp/backstage-showcase
     backstage.io/kubernetes-namespace: janus-idp
     sonarqube.org/project-key: janus-idp_backstage-showcase

--- a/packages/app/src/components/catalog/EntityPage/Content/CI.tsx
+++ b/packages/app/src/components/catalog/EntityPage/Content/CI.tsx
@@ -21,9 +21,33 @@ const ifCIs: ((e: Entity) => boolean)[] = [
   isTektonCIAvailable,
 ];
 
+const ifTektonAndGitlabCIs: ((e: Entity) => boolean)[] = [
+  isGitlabAvailable,
+  isTektonCIAvailable,
+];
+
+const ifTektonAndGithubActionsCIs: ((e: Entity) => boolean)[] = [
+  isGithubActionsAvailable,
+  isTektonCIAvailable,
+];
+
+const ifGithubQActionsAndGitlabCIs: ((e: Entity) => boolean)[] = [
+  isGitlabAvailable,
+  isGithubActionsAvailable,
+];
+
 export const isCIsAvailable = (e: Entity) => ifCIs.some(f => f(e));
 
 export const areAllCIsAvailable = (e: Entity) => ifCIs.every(f => f(e));
+
+export const areGithubActionsAndGitlabCIsAvailable = (e: Entity) =>
+  ifGithubQActionsAndGitlabCIs.every(f => f(e));
+
+export const areGithubActionsAndTektonCIsAvailable = (e: Entity) =>
+  ifTektonAndGithubActionsCIs.every(f => f(e));
+
+export const areTektonAndGitlabCIsAvailable = (e: Entity) =>
+  ifTektonAndGitlabCIs.every(f => f(e));
 
 export const ciContent = (
   <Grid container spacing={3} justifyContent="space-evenly">
@@ -32,6 +56,33 @@ export const ciContent = (
         <Grid item xs={12}>
           <EntityGithubActionsContent />
         </Grid>
+        <Grid item xs={12}>
+          <EntityGitlabMergeRequestsTable />
+        </Grid>
+        <Grid item xs={12}>
+          <LatestPipelineRun linkTekton />
+        </Grid>
+      </EntitySwitch.Case>
+
+      <EntitySwitch.Case if={areGithubActionsAndGitlabCIsAvailable}>
+        <Grid item xs={12}>
+          <EntityGithubActionsContent />
+        </Grid>
+        <Grid item xs={12}>
+          <EntityGitlabMergeRequestsTable />
+        </Grid>
+      </EntitySwitch.Case>
+
+      <EntitySwitch.Case if={areGithubActionsAndTektonCIsAvailable}>
+        <Grid item xs={12}>
+          <EntityGithubActionsContent />
+        </Grid>
+        <Grid item xs={12}>
+          <LatestPipelineRun linkTekton />
+        </Grid>
+      </EntitySwitch.Case>
+
+      <EntitySwitch.Case if={areTektonAndGitlabCIsAvailable}>
         <Grid item xs={12}>
           <EntityGitlabMergeRequestsTable />
         </Grid>


### PR DESCRIPTION
## Description

The [PR](https://github.com/janus-idp/backstage-showcase/pull/234) adds the tekton plugin to the showcase app, but the pipelinerun visualization will appear on the CI tab only if the Component entity has the annotation `janus-idp.io/tekton-enabled: 'true'`. Without this change, the users using the showcase app will have to add another catalog entity with the above-mentioned annotation to view the latest pipelinerun visualization in the CI tab of that entity.

## Screenshot
Component entity has `GithubActions` and `Tekton` CIs enabled

<img width="1693" alt="Screenshot 2023-05-08 at 11 33 33 PM" src="https://user-images.githubusercontent.com/22490998/236897554-7d3bb9ba-2ac3-4078-80af-04f9a3d90892.png">

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

