### PR TITLE
feat: modify app-configs so default entrypoint can be used by helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,10 +88,10 @@ COPY --from=build /opt/app-root/src/packages/backend/dist/bundle.tar.gz .
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 # Copy any other files that we need at runtime
-COPY ./app-config.yaml ./app-config.production.yaml ./
+COPY ./app-config.yaml ./app-config.production.yaml ./app-config.example.yaml ./app-config.example.production.yaml ./
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./
 
-CMD ["node", "packages/backend", "--config", "app-config.yaml"]
+ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]

--- a/app-config.example.production.yaml
+++ b/app-config.example.production.yaml
@@ -1,0 +1,24 @@
+app:
+  # Should be the same as backend.baseUrl when using the `app-backend` plugin.
+  baseUrl: http://localhost:7007
+
+backend:
+  # Note that the baseUrl should be the URL that the browser and other clients
+  # should use when communicating with the backend, i.e. it needs to be
+  # reachable not just from within the backend host, but from all of your
+  # callers. When its value is "http://localhost:7007", it's strictly private
+  # and can't be reached by others.
+  baseUrl: http://localhost:7007
+  # The listener can also be expressed as a single <host>:<port> string. In this case we bind to
+  # all interfaces, the most permissive setting. The right value depends on your specific deployment.
+  listen:
+    port: 7007
+
+  # config options: https://node-postgres.com/api/client
+  database:
+    client: pg
+    connection:
+      host: ${POSTGRES_HOST}
+      password: ${POSTGRES_PASSWORD}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}

--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -43,6 +43,13 @@ integrations:
           webhookSecret: temp
           privateKey: |
             temp
+auth:
+  environment: development
+  providers:
+    github:
+      development:
+        clientId: temp
+        clientSecret: temp
 
 techdocs:
   builder: external

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -32,6 +32,7 @@ spec:
           command:
             - node
             - packages/backend
+          args:
             - --config
             - app-config.yaml
             - --config

--- a/showcase-docs/getting-started.md
+++ b/showcase-docs/getting-started.md
@@ -6,7 +6,7 @@ There are several different methods for running the Backstage Showcase app today
 
 The easiest and fastest method for getting started: Backstage Showcase app, running it locally only requires a few simple steps.
 
-1. Copy `app-config.basic.yaml` and rename it as `app-config.local.yaml`.
+1. Copy `app-config.example.yaml` and rename it as `app-config.local.yaml`.
 
 ## Running Locally with the Optional Plugins
 


### PR DESCRIPTION
## Description

Chasing https://github.com/janus-idp/book/issues/14 we want to be able to run this image "as is" which should enable users to replicate a default Showcase setup. That means: most custom features are disabled because of missing credentials, but the pod starts and runs fine.

Therefore I'm proposing:

- rename `app-config.basic.yaml` to `app-config.example.yaml`
- add `app-config.example.production.yaml` which enables postgres and routes frontend via backend (similar to `app-config.production.yaml`, but without certificates and using different variable names that are available through the upstream helm chart)
- change `CMD` to `ENTRYPOINT` so it doesn't get overwritten by dynamic `args` in the pod spec of the Helm chart
- change the entrypoint arguments to list all configs that should be enabld when running the example application
- update `manifests/base/deployment.yaml` so Janus Showcase doesn't propagate any of these changes into its configuration.

## Which issue(s) does this PR fix

Part of https://github.com/janus-idp/book/issues/14

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
