### PR TITLE
Added mkdocs to Dockerfile to run local techdocs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,9 @@ ENV SEGMENT_WRITE_KEY=temp
 ENV SEGMENT_TEST_MODE=true
 
 # Install gzip for tar and clean up
-RUN microdnf install -y gzip && microdnf clean all
+RUN microdnf install -y gzip python3 python3-pip && \
+    pip3 install mkdocs-techdocs-core==1.2.1 && \
+    microdnf clean all
 
 COPY --from=build --chown=1001:1001 /opt/app-root/src/.yarn ./.yarn
 COPY --from=build --chown=1001:1001 /opt/app-root/src/.yarnrc.yml ./


### PR DESCRIPTION
## Description

Added `mkdocs` to the showcase image in order to run techdocs in a local setup mode

## Which issue(s) does this PR fix

- Fixes #265 

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
