### PR TITLE
fix(example): missing argo instance url prevents container from startint

### DIFF
--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -43,6 +43,18 @@ integrations:
           webhookSecret: temp
           privateKey: |
             temp
+
+argocd:
+  appLocatorMethods:
+    - type: 'config'
+      instances:
+        - name: argoInstance1
+          url: temp
+          token: temp
+        - name: argoInstance2
+          url: temp
+          token: temp
+
 auth:
   environment: development
   providers:


### PR DESCRIPTION
## Description

Adds defaults for ArgoCD plugin when example setup is used.

## Which issue(s) does this PR fix

- Fixes https://github.com/janus-idp/backstage-showcase/issues/287

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
