### PR TITLE
chore(monorepo): add Paul and Patrick as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @christophe-f @gorkem
+*  @christophe-f @gorkem @schultzp2020 @PatAKnight


### PR DESCRIPTION
## Description

Please explain the changes you made here.

The CODEOWNERS file is used to notify users of a pull request.

## Which issue(s) does this PR fix

- Fixes https://github.com/janus-idp/backstage-showcase/issues/313

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
