### PR TITLE
chore: add missing CRs to kubernetes plugin for topology

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -220,10 +220,16 @@ kubernetes:
   customResources:
     - group: 'tekton.dev'
       apiVersion: 'v1beta1'
+      plural: 'pipelines'
+    - group: 'tekton.dev'
+      apiVersion: 'v1beta1'
       plural: 'pipelineruns'
     - group: 'tekton.dev'
       apiVersion: 'v1beta1'
       plural: 'taskruns'
+    - group: 'route.openshift.io'
+      apiVersion: 'v1'
+      plural: 'routes'
   serviceLocatorMethod:
     type: 'multiTenant'
   clusterLocatorMethods:


### PR DESCRIPTION
## Description

I've noticed missing default configuration for topology `1.7.0` and `1.8.0` (we're at `^1.7.0` in this instance, but it doesn't hurt to be future-proof)

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
