### PR TITLE
chore: update homepage links

### DIFF
--- a/packages/app/public/homepage/data.json
+++ b/packages/app/public/homepage/data.json
@@ -58,12 +58,12 @@
       {
         "iconUrl": "/homepage/icons/argo-icon-color.svg",
         "label": "ArgoCD",
-        "url": ""
+        "url": "https://openshift-gitops-server-openshift-gitops.apps.janus.djpe.p1.openshiftapps.com/"
       },
       {
         "iconUrl": "/homepage/icons/sonarqube.svg",
-        "label": "SonarQube (Coming Soon)",
-        "url": ""
+        "label": "SonarQube",
+        "url": "https://sonarqube.apps.janus.djpe.p1.openshiftapps.com/"
       },
       {
         "iconUrl": "/homepage/icons/quay.svg",
@@ -79,7 +79,7 @@
       {
         "iconUrl": "/homepage/icons/icons8/openshift.png",
         "label": "OpenShift",
-        "url": ""
+        "url": "https://console-openshift-console.apps.janus.djpe.p1.openshiftapps.com/"
       }
     ]
   },
@@ -88,7 +88,7 @@
     "links": [
       {
         "iconUrl": "/homepage/icons/icons8/system-task.png",
-        "label": "Grafana",
+        "label": "Grafana (Coming Soon)",
         "url": ""
       }
     ]
@@ -104,12 +104,7 @@
       {
         "iconUrl": "/homepage/icons/keycloak.svg",
         "label": "Keycloak",
-        "url": ""
-      },
-      {
-        "iconUrl": "/homepage/icons/icons8/safe-out.png",
-        "label": "Vault",
-        "url": ""
+        "url": "https://keycloak.apps.janus.djpe.p1.openshiftapps.com/"
       }
     ]
   }


### PR DESCRIPTION
## Description

Updated the Openshift, Keycloak, ArgoCD, SonarQube links.
Removed Vault since we are no longer using it.
Set the Grafana as "Coming Soon", since we might use it in the future.

## Which issue(s) does this PR fix

- Fixes #339

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
