### PR TITLE
chore(deps): update topology plugin to 1.10.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
     "@janus-idp/backstage-plugin-ocm": "^3.0.2",
     "@janus-idp/backstage-plugin-quay": "^1.2.13",
     "@janus-idp/backstage-plugin-tekton": "^1.6.0",
-    "@janus-idp/backstage-plugin-topology": "^1.9.0",
+    "@janus-idp/backstage-plugin-topology": "^1.10.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.132",
     "@mui/material": "^5.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6219,18 +6219,19 @@
     react-measure "2.5.2"
     react-use "^17.2.4"
 
-"@janus-idp/backstage-plugin-topology@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-topology/-/backstage-plugin-topology-1.9.0.tgz#9755db1c6ace95c684bee2f46c15f90aa763b5e7"
-  integrity sha512-/oCmTUNKa2wNXpAQ7RaJwutwEfoTOY5LnNr9DHDJvLy7Ug1NKnLDpQZulAoPoPcf7jGHAq9S/w3hk4HJTj8U/A==
+"@janus-idp/backstage-plugin-topology@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/backstage-plugin-topology/-/backstage-plugin-topology-1.10.0.tgz#51f5db8b4b6e602113e98609487c829a62829951"
+  integrity sha512-AyCT3NAfdvYtOXK3gi9pIfioiIgekPoH8/+SqV6coh56RaglF7jOfrwMPW8aIfofZJOzEudlLMXj88CSKiRwIQ==
   dependencies:
-    "@backstage/catalog-model" "^1.3.0"
-    "@backstage/core-components" "^0.13.1"
-    "@backstage/core-plugin-api" "^1.5.1"
-    "@backstage/plugin-catalog-react" "^1.6.0"
-    "@backstage/plugin-kubernetes" "^0.9.1"
-    "@backstage/plugin-kubernetes-common" "^0.6.3"
-    "@backstage/theme" "^0.3.0"
+    "@backstage/catalog-model" "^1.4.1"
+    "@backstage/core-components" "^0.13.3"
+    "@backstage/core-plugin-api" "^1.5.3"
+    "@backstage/plugin-catalog-react" "^1.8.0"
+    "@backstage/plugin-kubernetes" "^0.9.3"
+    "@backstage/plugin-kubernetes-common" "^0.6.5"
+    "@backstage/theme" "^0.4.1"
+    "@janus-idp/shared-react" "1.1.0"
     "@kubernetes/client-node" "^0.18.1"
     "@material-ui/core" "^4.9.13"
     "@material-ui/icons" "^4.9.1"
@@ -6246,6 +6247,14 @@
     js-yaml "^4.1.0"
     lodash "^4.17.19"
     react-use "^17.2.4"
+
+"@janus-idp/shared-react@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@janus-idp/shared-react/-/shared-react-1.1.0.tgz#937e6a515bf3975f95abcd9cdb0aa11838b170c9"
+  integrity sha512-4TRrEq39klGE5F7ecLbc1fOY42bEiIZTKbugUdNI/oSboKPy1uTkox5gbtu1O3uTatJgv53Cfd5Ac6/YeoCcgg==
+  dependencies:
+    "@kubernetes/client-node" "^0.18.1"
+    classnames "2.3.2"
 
 "@jest-mock/express@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
## Resolves
https://github.com/janus-idp/backstage-showcase/issues/394

## Description

This PR updates the version of @janus-idp/backstage-plugin-topology from
1.9.0 -> 1.10.0


## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
