### PR TITLE
Add GH action for freeing up disk space

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -56,6 +56,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 


### PR DESCRIPTION
## Description

This PR addresses the issue of our GitHub actions failing. Whenever we build a new image, we either fail with the error `System.IO.IOException: No space left on device` or we time out. This PR adds a new step that frees up the disk space, giving us more room back for whenever we build.

This step is removing the packages that are included within the GitHub runner. These include android, dotnet, and haskell. 

More [information](https://github.com/jlumbroso/free-disk-space) on the GitHub action.
An [example](https://github.com/janus-idp/backstage-showcase/actions/runs/5685267404) of the failing GH action

## Which issue(s) does this PR fix

- Fixes #425 

## PR acceptance criteria

Please make sure that the following steps are complete:

- GitHub Actions are completed and successful
- Unit Tests are updated and passing
- E2E Tests are updated and passing
- Documentation is updated if necessary
- Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
