### PR TITLE
added support for labels, for supporting image expiration

### DIFF
--- a/.changeset/image-labels-support.md
+++ b/.changeset/image-labels-support.md
@@ -1,0 +1,35 @@
+---
+<!-- im not sure if we really need a VersionPump since the changes are only related to the CI -->
+'app': patch
+'backend': patch
+---
+
+Implemented Support for Custom Docker Image Labels in GitHub Actions Workflow:
+
+Incorporated functionality to seamlessly manage custom labels for Docker images within the GitHub Actions workflow. The enhancements were made as follows:
+
+1. **Enhanced Action Configuration (`action.yaml`):**
+   - Introduced the `imageLabels` parameter in the Docker build action configuration.
+   - The `imageLabels` parameter empowers users to define custom labels for Docker images during the build process.
+2. **Improved Workflow Configuration (`nightly.yaml`):**
+   - Introduced the `imageLabels` parameter in the workflow configuration.
+   - Illustrative usage: Setting `imageLabels: quay.expires-after=14d` to specify a 14-day expiration for images.
+   - When executing the nightly workflow, the Docker image will be enriched with the designated labels.
+
+**Usage Guide:**
+To leverage the new `imageLabels` parameter, navigate to the workflow configuration (`nightly.yaml`) and modify the `imageLabels` parameter as needed:
+
+```yaml
+jobs:
+  release:
+    ...
+    steps:
+      ...
+      - name: Publish
+        uses: ./.github/actions/docker-build
+        with:
+          ...
+          imageLabels: "quay.expires-after=14d" # modify this
+          push: true
+
+```

--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -30,6 +30,9 @@ inputs:
   imageTags:
     description: The tags to apply to the image
     required: true
+  imageLabels:
+    description: The labels for the Docker image
+    required: false
   push:
     description: Whether to push the image
     required: true
@@ -77,6 +80,8 @@ runs:
         images: ${{ inputs.registry }}/${{ inputs.imageName }}
         tags: |
           ${{ inputs.imageTags }}
+        labels: |
+          ${{ inputs.imageLabels }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -37,4 +37,5 @@ jobs:
           imageName: ${{ env.IMAGE_NAME }}
           imageTags: |
             type=schedule,pattern={{date 'YYYYMMDD'}},prefix=nightly-
+          imageLabels: quay.expires-after=14d
           push: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '0 19 * * *'
+    - cron: '0 4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}


### PR DESCRIPTION
## Description

1. add `imageLabels: quay.expires-after=14d` to  `.github/workflows/nightly.yaml`.
this label sets the image expiration period in Quay.io
2. use the new ket in `.github/actions/docker-build/action.yaml`, under the `meta` step
3. add `labels: ${{ steps.meta.outputs.labels }}` under `Build and push Docker image` step, this where the actual label is being consumed and set to the newly created image
4. set `imageLabels` under `.github/actions/docker-build/action.yaml` inputs, as non required input

## Which issue(s) does this PR fix

- Fixes #474 

## How to test changes / Special notes to the reviewer

- expect to see expires label in newly pushed nightly images
