### PR TITLE
feat(app): make branding icons and primary color configurable

### DIFF
--- a/.changeset/shy-cobras-tease.md
+++ b/.changeset/shy-cobras-tease.md
@@ -2,4 +2,4 @@
 'app': minor
 ---
 
-Adds ability to configure branding icons and primarty color
+Adds ability to configure branding icons and primary color

--- a/.changeset/shy-cobras-tease.md
+++ b/.changeset/shy-cobras-tease.md
@@ -1,0 +1,5 @@
+---
+'app': minor
+---
+
+Adds ability to configure branding icons and primarty color

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -7,4 +7,28 @@ export interface Config {
      */
     proxyPath?: string;
   };
+  app: {
+    branding?: {
+      /**
+       * Base64 URI for the full logo
+       * @visibility frontend
+       */
+      fullLogo?: string;
+      /**
+       * Base64 URI for the icon logo
+       * @visibility frontend
+       */
+      iconLogo?: string;
+      theme?: {
+        [key: string]: {
+          /**
+           * primaryColor Configuration for the instance
+           * The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()
+           * @visibility frontend
+           */
+          primaryColor: string;
+        };
+      };
+    };
+  };
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,6 +81,7 @@
     "@testing-library/dom": "8.20.1",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "12.1.5",
+    "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/node": "18.17.17",
     "@types/react": "17.0.65",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -52,6 +52,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { customLightTheme } from './themes/lightTheme';
 import { customDarkTheme } from './themes/darkTheme';
+import { useUpdateTheme } from './hooks/useUpdateTheme';
 
 const app = createApp({
   apis,
@@ -78,18 +79,30 @@ const app = createApp({
       title: 'Light Theme',
       variant: 'light',
       icon: <LightIcon />,
-      Provider: ({ children }) => (
-        <UnifiedThemeProvider theme={customLightTheme} children={children} />
-      ),
+      Provider: ({ children }) => {
+        const { primaryColor } = useUpdateTheme('light');
+        return (
+          <UnifiedThemeProvider
+            theme={customLightTheme(primaryColor)}
+            children={children}
+          />
+        );
+      },
     },
     {
       id: 'dark',
       title: 'Dark Theme',
       variant: 'dark',
       icon: <DarkIcon />,
-      Provider: ({ children }) => (
-        <UnifiedThemeProvider theme={customDarkTheme} children={children} />
-      ),
+      Provider: ({ children }) => {
+        const { primaryColor } = useUpdateTheme('dark');
+        return (
+          <UnifiedThemeProvider
+            theme={customDarkTheme(primaryColor)}
+            children={children}
+          />
+        );
+      },
     },
   ],
   components: {

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,4 @@
 import {
-  Link,
   Sidebar,
   SidebarDivider,
   SidebarGroup,
@@ -7,7 +6,6 @@ import {
   SidebarPage,
   SidebarScrollWrapper,
   SidebarSpace,
-  useSidebarOpenState,
 } from '@backstage/core-components';
 import { SidebarSearchModal } from '@backstage/plugin-search';
 import {
@@ -26,28 +24,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import StorageIcon from '@mui/icons-material/Storage';
 import AssessmentIcon from '@mui/icons-material/Assessment';
 import React, { PropsWithChildren } from 'react';
-import { makeStyles } from 'tss-react/mui';
-import LogoFull from './LogoFull';
-import LogoIcon from './LogoIcon';
-
-const useStyles = makeStyles()({
-  sidebarLogo: {
-    margin: '24px 0px 6px 24px',
-  },
-});
-
-const SidebarLogo = () => {
-  const { classes } = useStyles();
-  const { isOpen } = useSidebarOpenState();
-
-  return (
-    <div className={classes.sidebarLogo}>
-      <Link to="/" underline="none" aria-label="Home">
-        {isOpen ? <LogoFull /> : <LogoIcon />}
-      </Link>
-    </div>
-  );
-};
+import { SidebarLogo } from './SidebarLogo';
 
 export const Root = ({ children }: PropsWithChildren<{}>) => (
   <SidebarPage>

--- a/packages/app/src/components/Root/SidebarLogo.test.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useSidebarOpenState } from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+import { BrowserRouter } from 'react-router-dom';
+import { SidebarLogo } from './SidebarLogo';
+
+jest.mock('@backstage/core-components', () => ({
+  ...jest.requireActual('@backstage/core-components'),
+  useSidebarOpenState: jest.fn(),
+}));
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+jest.mock('./LogoFull.tsx', () => () => (
+  <svg data-testid="default-full-logo" />
+));
+jest.mock('./LogoIcon.tsx', () => () => (
+  <svg data-testid="default-icon-logo" />
+));
+
+describe('SidebarLogo', () => {
+  it('when sidebar is open renders the component with full logo base64 provided by config', () => {
+    (useApi as any).mockReturnValue({
+      getOptionalString: jest.fn().mockReturnValue('fullLogoBase64URI'),
+    });
+
+    (useSidebarOpenState as any).mockReturnValue({ isOpen: true });
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <SidebarLogo />
+      </BrowserRouter>,
+    );
+
+    const fullLogo = getByTestId('home-logo');
+    expect(fullLogo).toBeInTheDocument();
+    expect(fullLogo).toHaveAttribute('src', 'fullLogoBase64URI'); // Check the expected attribute value
+  });
+
+  it('when sidebar is open renders the component with default full logo if config is undefined', () => {
+    (useApi as any).mockReturnValue({
+      getOptionalString: jest.fn().mockReturnValue(undefined),
+    });
+
+    (useSidebarOpenState as any).mockReturnValue({ isOpen: true });
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <SidebarLogo />
+      </BrowserRouter>,
+    );
+
+    expect(getByTestId('default-full-logo')).toBeInTheDocument();
+  });
+
+  it('when sidebar is closed renders the component with icon logo base64 provided by config', () => {
+    (useApi as any).mockReturnValue({
+      getOptionalString: jest.fn().mockReturnValue('iconLogoBase64URI'),
+    });
+
+    (useSidebarOpenState as any).mockReturnValue({ isOpen: false });
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <SidebarLogo />
+      </BrowserRouter>,
+    );
+
+    const fullLogo = getByTestId('home-logo');
+    expect(fullLogo).toBeInTheDocument();
+    expect(fullLogo).toHaveAttribute('src', 'iconLogoBase64URI');
+  });
+
+  it('when sidebar is closed renders the component with icon logo from default if not provided with config', () => {
+    (useApi as any).mockReturnValue({
+      getOptionalString: jest.fn().mockReturnValue(undefined),
+    });
+
+    (useSidebarOpenState as any).mockReturnValue({ isOpen: false });
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <SidebarLogo />
+      </BrowserRouter>,
+    );
+
+    expect(getByTestId('default-icon-logo')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/Root/SidebarLogo.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.tsx
@@ -1,0 +1,65 @@
+import { Link, useSidebarOpenState } from '@backstage/core-components';
+import React from 'react';
+import { makeStyles } from 'tss-react/mui';
+import LogoFull from './LogoFull';
+import LogoIcon from './LogoIcon';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+const useStyles = makeStyles()({
+  sidebarLogo: {
+    margin: '24px 0px 6px 24px',
+  },
+});
+
+const LogoRender = ({
+  base64Logo,
+  defaultLogo,
+  width,
+}: {
+  base64Logo: string | undefined;
+  defaultLogo: React.JSX.Element;
+  width: number;
+}) => {
+  return base64Logo ? (
+    <img
+      data-testid="home-logo"
+      src={base64Logo}
+      alt="Home logo"
+      width={width}
+    />
+  ) : (
+    defaultLogo
+  );
+};
+
+export const SidebarLogo = () => {
+  const { classes } = useStyles();
+  const { isOpen } = useSidebarOpenState();
+  const configApi = useApi(configApiRef);
+  const logoFullBase64URI = configApi.getOptionalString(
+    'app.branding.fullLogo',
+  );
+  const logoIconBase64URI = configApi.getOptionalString(
+    'app.branding.iconLogo',
+  );
+
+  return (
+    <div className={classes.sidebarLogo}>
+      <Link to="/" underline="none" aria-label="Home">
+        {isOpen ? (
+          <LogoRender
+            base64Logo={logoFullBase64URI}
+            defaultLogo={<LogoFull />}
+            width={110}
+          />
+        ) : (
+          <LogoRender
+            base64Logo={logoIconBase64URI}
+            defaultLogo={<LogoIcon />}
+            width={28}
+          />
+        )}
+      </Link>
+    </div>
+  );
+};

--- a/packages/app/src/hooks/useUpdateTheme.test.ts
+++ b/packages/app/src/hooks/useUpdateTheme.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useApi } from '@backstage/core-plugin-api';
+import { useUpdateTheme } from './useUpdateTheme';
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: jest.fn(),
+}));
+
+describe('useUpdateTheme', () => {
+  it('returns the primaryColor when config is available', () => {
+    (useApi as any).mockReturnValue({
+      getOptionalString: jest.fn().mockReturnValue('blue'),
+    });
+
+    const { result } = renderHook(() => useUpdateTheme('someTheme'));
+    expect(result.current.primaryColor).toBe('blue');
+  });
+
+  it('returns undefined when config is unavailable', () => {
+    // Mock the useApi function to throw an error (simulate unavailable config)
+    (useApi as any).mockImplementation(
+      jest.fn(() => {
+        throw new Error('Custom hook error');
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateTheme('someTheme'));
+    expect(result.current.primaryColor).toBeUndefined();
+  });
+});

--- a/packages/app/src/hooks/useUpdateTheme.ts
+++ b/packages/app/src/hooks/useUpdateTheme.ts
@@ -1,0 +1,16 @@
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+
+export const useUpdateTheme = (
+  selTheme: string,
+): { primaryColor: string | undefined } => {
+  let primaryColor: string | undefined;
+  try {
+    const configApi = useApi(configApiRef);
+    primaryColor = configApi.getOptionalString(
+      `app.branding.theme.${selTheme}.primaryColor`,
+    );
+  } catch (err) {
+    // useApi won't be initialized initally in createApp theme provider, and will get updated later
+  }
+  return { primaryColor };
+};

--- a/packages/app/src/themes/darkTheme.ts
+++ b/packages/app/src/themes/darkTheme.ts
@@ -3,22 +3,29 @@ import { components } from './componentOverrides';
 import { pageFontFamily, typography } from './consts';
 import { pageTheme } from './pageTheme';
 
-export const customDarkTheme = createUnifiedTheme({
-  fontFamily: pageFontFamily,
-  palette: {
-    ...themes.dark.getTheme('v5')?.palette,
-    navigation: {
-      background: '#0f1214',
-      indicator: '#009596',
-      color: '#ffffff',
-      selectedColor: '#ffffff',
-      navItem: {
-        hoverBackground: '#030303',
+export const customDarkTheme = (primaryColor?: string | undefined) =>
+  createUnifiedTheme({
+    fontFamily: pageFontFamily,
+    palette: {
+      ...themes.dark.getTheme('v5')?.palette,
+      ...(primaryColor && {
+        primary: {
+          ...themes.light.getTheme('v5')?.palette.primary,
+          main: primaryColor,
+        },
+      }),
+      navigation: {
+        background: '#0f1214',
+        indicator: '#009596',
+        color: '#ffffff',
+        selectedColor: '#ffffff',
+        navItem: {
+          hoverBackground: '#030303',
+        },
       },
     },
-  },
-  defaultPageTheme: 'home',
-  pageTheme,
-  components,
-  typography,
-});
+    defaultPageTheme: 'home',
+    pageTheme,
+    components,
+    typography,
+  });

--- a/packages/app/src/themes/lightTheme.ts
+++ b/packages/app/src/themes/lightTheme.ts
@@ -3,22 +3,29 @@ import { components } from './componentOverrides';
 import { pageFontFamily, typography } from './consts';
 import { pageTheme } from './pageTheme';
 
-export const customLightTheme = createUnifiedTheme({
-  fontFamily: pageFontFamily,
-  palette: {
-    ...themes.light.getTheme('v5')?.palette,
-    navigation: {
-      background: '#222427',
-      indicator: '#009596',
-      color: '#ffffff',
-      selectedColor: '#ffffff',
-      navItem: {
-        hoverBackground: '#4f5255',
+export const customLightTheme = (primaryColor?: string | undefined) =>
+  createUnifiedTheme({
+    fontFamily: pageFontFamily,
+    palette: {
+      ...themes.light.getTheme('v5')?.palette,
+      ...(primaryColor && {
+        primary: {
+          ...themes.light.getTheme('v5')?.palette.primary,
+          main: primaryColor,
+        },
+      }),
+      navigation: {
+        background: '#222427',
+        indicator: '#009596',
+        color: '#ffffff',
+        selectedColor: '#ffffff',
+        navItem: {
+          hoverBackground: '#4f5255',
+        },
       },
     },
-  },
-  defaultPageTheme: 'home',
-  pageTheme,
-  components,
-  typography,
-});
+    defaultPageTheme: 'home',
+    pageTheme,
+    components,
+    typography,
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8806,6 +8806,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@12.1.5", "@testing-library/react@^12.1.3":
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
@@ -21256,6 +21264,13 @@ react-dropzone@9.0.0:
     file-selector "^0.1.8"
     prop-types "^15.6.2"
     prop-types-extra "^1.1.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.11:
   version "6.0.11"


### PR DESCRIPTION
## Description

Please explain the changes you made here.

Provides the ability to customize the branding for Janus. User can update Icons and primary color with configurations in app-config.yaml for multiple themes.

```
 app:
  branding:
    fullLogo: ${BASE64_SVG_FULL_LOGO_URI}
    iconLogo: ${BASE64_SVG_ICON_LOGO_URI}
    theme:
      - light:
          primaryColor: ${PRIMARY_LIGHT_COLOR}
      - dark:
          primaryColor: ${PRIMARY_DARK_COLOR}
```

**Screenshots:**

Light Theme

<img width="1728" alt="image" src="https://github.com/janus-idp/backstage-showcase/assets/5129024/9e8693ab-930e-4b14-ae05-4ff5dc7fc4ca">


Dark Theme:

<img width="1728" alt="image" src="https://github.com/janus-idp/backstage-showcase/assets/5129024/3bd5a966-1764-4e58-9ee6-626d59249fcf">


## Which issue(s) does this PR fix

- Fixes https://github.com/janus-idp/backstage-showcase/issues/540

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
