### PR TITLE
fix : fix a bug in the upstream CommonJSModuleLoader

### DIFF
--- a/.changeset/thirty-bags-kiss.md
+++ b/.changeset/thirty-bags-kiss.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Fix a bug in the upstream CommonJSLoader, which prevented laoding modules from embedded node_modules folders of private packages located in the plugin node_modules folder.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,6 +49,7 @@ import {
   LegacyPluginEnvironment as PluginEnvironment,
 } from '@backstage/backend-plugin-manager';
 import { DefaultEventBroker } from '@backstage/plugin-events-backend';
+import { CommonJSModuleLoader } from './loader/CommonJSModuleLoader';
 
 function makeCreateEnv(config: Config, pluginProvider: BackendPluginProvider) {
   const root = getRootLogger();
@@ -161,7 +162,12 @@ async function main() {
     argv: process.argv,
     logger,
   });
-  const pluginManager = await PluginManager.fromConfig(config, logger);
+  const pluginManager = await PluginManager.fromConfig(
+    config,
+    logger,
+    undefined,
+    new CommonJSModuleLoader(logger),
+  );
   const createEnv = makeCreateEnv(config, pluginManager);
 
   const appEnv = useHotMemoize(module, () => createEnv('app'));

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,6 +49,12 @@ import {
   LegacyPluginEnvironment as PluginEnvironment,
 } from '@backstage/backend-plugin-manager';
 import { DefaultEventBroker } from '@backstage/plugin-events-backend';
+
+// TODO(davidfestal): The following import is a temporary workaround for a bug
+// in the upstream @backstage/backend-plugin-manager package.
+//
+// It should be removed as soon as the upstream package is fixed and released.
+// see https://github.com/janus-idp/backstage-showcase/pull/600
 import { CommonJSModuleLoader } from './loader/CommonJSModuleLoader';
 
 function makeCreateEnv(config: Config, pluginProvider: BackendPluginProvider) {

--- a/packages/backend/src/loader/CommonJSModuleLoader.ts
+++ b/packages/backend/src/loader/CommonJSModuleLoader.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModuleLoader } from '@backstage/backend-plugin-manager';
+
+import path from 'path';
+import { Logger } from 'winston';
+
+export class CommonJSModuleLoader implements ModuleLoader {
+  constructor(public readonly logger: Logger) {}
+
+  async bootstrap(
+    backstageRoot: string,
+    dynamicPluginsPaths: string[],
+  ): Promise<void> {
+    const backstageRootNodeModulesPath = `${backstageRoot}/node_modules`;
+    const dynamicNodeModulesPaths = [
+      ...dynamicPluginsPaths.map(p => path.resolve(p, 'node_modules')),
+    ];
+    const Module = require('module');
+    const oldNodeModulePaths = Module._nodeModulePaths;
+    Module._nodeModulePaths = (from: string): string[] => {
+      const result: string[] = oldNodeModulePaths(from);
+      if (!dynamicPluginsPaths.some(p => from.startsWith(p))) {
+        return result;
+      }
+      const filtered = result.filter(nodeModulePath => {
+        return (
+          nodeModulePath === backstageRootNodeModulesPath ||
+          dynamicNodeModulesPaths.some(p => nodeModulePath.startsWith(p))
+        );
+      });
+      this.logger.debug(
+        `Overriding node_modules search path for dynamic plugin ${from} to: ${filtered}`,
+      );
+      return filtered;
+    };
+  }
+
+  async load(packagePath: string): Promise<any> {
+    return await import(/* webpackIgnore: true */ packagePath);
+  }
+}


### PR DESCRIPTION
## Description

Fix a bug in the upstream `CommonJSLoader`, which prevented laoding modules from embedded `node_modules` folders of private packages located in the plugin `node_modules` folder.

This is a fixed version of the [corresponding upstream code](https://github.com/backstage/backstage/blob/master/packages/backend-plugin-manager/src/loader/CommonJSModuleLoader.ts).

A PR on the upstream repository will follow, but until the change lands upstream and can be imported into the showcase after the next release, we will use the fixed loader added in the showcase application itself.

## Which issue(s) does this PR fix

No issue

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
