### PR TITLE
feat(dynamic-plugins): add wrappers for frontend plugins

### DIFF
--- a/.changeset/grumpy-mugs-cover.md
+++ b/.changeset/grumpy-mugs-cover.md
@@ -1,0 +1,35 @@
+---
+'backstage-plugin-scaffolder-backend-module-gitlab': patch
+'immobiliarelabs-backstage-plugin-gitlab-backend': patch
+'backstage-plugin-catalog-backend-module-github': patch
+'backstage-plugin-catalog-backend-module-gitlab': patch
+'roadiehq-backstage-plugin-github-pull-requests': patch
+'janus-idp-backstage-plugin-keycloak-backend': patch
+'roadiehq-backstage-plugin-security-insights': patch
+'roadiehq-backstage-plugin-argo-cd-backend': patch
+'roadiehq-backstage-plugin-github-insights': patch
+'roadiehq-scaffolder-backend-module-utils': patch
+'immobiliarelabs-backstage-plugin-gitlab': patch
+'janus-idp-backstage-plugin-aap-backend': patch
+'janus-idp-backstage-plugin-ocm-backend': patch
+'backstage-plugin-azure-devops-backend': patch
+'backstage-plugin-kubernetes-backend': patch
+'backstage-plugin-sonarqube-backend': patch
+'roadiehq-scaffolder-backend-argocd': patch
+'backstage-plugin-techdocs-backend': patch
+'roadiehq-backstage-plugin-argo-cd': patch
+'roadiehq-backstage-plugin-datadog': patch
+'backstage-plugin-jenkins-backend': patch
+'backstage-plugin-github-actions': patch
+'backstage-plugin-github-issues': patch
+'roadiehq-backstage-plugin-jira': patch
+'backstage-plugin-azure-devops': patch
+'backstage-plugin-kubernetes': patch
+'backstage-plugin-lighthouse': patch
+'backstage-plugin-dynatrace': patch
+'backstage-plugin-pagerduty': patch
+'backstage-plugin-sonarqube': patch
+'backstage-plugin-jenkins': patch
+---
+
+Add a dynamic plugin wrapper for frontend plugins we consume from upstream

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules/
 # Build output
 dist
 dist-types
+dist-scalprum
 
 # Temporary change files created by Vim
 *.swp

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
@@ -32,7 +32,8 @@
     "@backstage/plugin-azure-devops-backend": "0.4.3"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-azure-devops",
+  "version": "0.3.7",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-azure-devops": "0.3.7"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.1"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-azure-devops",
+    "exposedModules": {
+      "AzureDevopsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-azure-devops';

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -30,7 +30,8 @@
     "@backstage/plugin-catalog-backend-module-github": "0.4.4"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -31,7 +31,7 @@
     "@backstage/plugin-catalog-backend-module-github": "0.4.4"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
@@ -33,7 +33,8 @@
     "@backstage/plugin-catalog-backend-module-gitlab": "0.3.3"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-dynatrace/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-dynatrace/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-dynatrace",
+  "version": "7.0.5",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-dynatrace": "7.0.5"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-dynatrace",
+    "exposedModules": {
+      "DynatracePlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-dynatrace/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-dynatrace/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-dynatrace';

--- a/dynamic-plugins/wrappers/backstage-plugin-github-actions/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-actions/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-github-actions",
+  "version": "0.6.6",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-github-actions": "0.6.6"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-github-actions",
+    "exposedModules": {
+      "GithubActionsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-github-actions/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-actions/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-github-actions';

--- a/dynamic-plugins/wrappers/backstage-plugin-github-issues/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-issues/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-github-issues",
+  "version": "0.2.14",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-github-issues": "0.2.14"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-github-issues",
+    "exposedModules": {
+      "GithubIssuesPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-github-issues/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-issues/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-github-issues';

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@backstage/plugin-jenkins-backend": "0.3.0"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-jenkins",
+  "version": "0.9.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-jenkins": "0.9.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-jenkins",
+    "exposedModules": {
+      "JenkinsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-jenkins';

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@backstage/plugin-kubernetes-backend": "0.13.0"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-kubernetes",
+  "version": "0.11.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-kubernetes": "0.11.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-kubernetes",
+    "exposedModules": {
+      "KubernetesPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-kubernetes';

--- a/dynamic-plugins/wrappers/backstage-plugin-lighthouse/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-lighthouse/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-lighthouse",
+  "version": "0.4.10",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-lighthouse": "0.4.10"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-lighthouse",
+    "exposedModules": {
+      "LighthousePlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-lighthouse/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-lighthouse/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-lighthouse';

--- a/dynamic-plugins/wrappers/backstage-plugin-pagerduty/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-pagerduty/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-pagerduty/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-pagerduty/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-pagerduty",
+  "version": "0.6.6",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-pagerduty": "0.6.6"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-pagerduty",
+    "exposedModules": {
+      "PagerdutyPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-pagerduty/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-pagerduty/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-pagerduty';

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
@@ -33,7 +33,8 @@
     "@backstage/plugin-scaffolder-backend-module-gitlab": "0.2.9"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
@@ -32,7 +32,8 @@
     "@backstage/plugin-sonarqube-backend": "0.2.8"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backstage-plugin-sonarqube",
+  "version": "0.7.7",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@backstage/plugin-sonarqube": "0.7.7"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "backstage.plugin-sonarqube",
+    "exposedModules": {
+      "SonarQubePlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@backstage/plugin-sonarqube';

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -35,7 +35,8 @@
     "dockerode": "3.3.5"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@immobiliarelabs/backstage-plugin-gitlab-backend": "6.2.0"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/.eslintrc.js
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "immobiliarelabs-backstage-plugin-gitlab",
+  "version": "6.2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@immobiliarelabs/backstage-plugin-gitlab": "6.2.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "immobiliarelabs.backstage-plugin-gitlab",
+    "exposedModules": {
+      "GitlabPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/src/index.ts
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@immobiliarelabs/backstage-plugin-gitlab';

--- a/dynamic-plugins/wrappers/janus-idp-backstage-plugin-aap-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/janus-idp-backstage-plugin-aap-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.2.3"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/janus-idp-backstage-plugin-keycloak-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/janus-idp-backstage-plugin-keycloak-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@janus-idp/backstage-plugin-keycloak-backend": "1.5.7"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/janus-idp-backstage-plugin-ocm-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/janus-idp-backstage-plugin-ocm-backend-dynamic/package.json
@@ -33,7 +33,8 @@
     "@janus-idp/backstage-plugin-ocm-backend": "3.2.3"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -32,7 +32,8 @@
     "@roadiehq/backstage-plugin-argo-cd-backend": "2.11.3"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-argo-cd",
+  "version": "2.3.5",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-argo-cd": "2.3.5"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-argo-cd",
+    "exposedModules": {
+      "ArgocdPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-argo-cd';

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-datadog",
+  "version": "2.2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-datadog": "2.2.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-datadog",
+    "exposedModules": {
+      "DatadogPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-datadog';

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-github-insights",
+  "version": "2.3.21",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-github-insights": "2.3.21"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-github-insights",
+    "exposedModules": {
+      "GithubInsightsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-github-insights';

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-github-pull-requests",
+  "version": "2.5.18",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-github-pull-requests": "2.5.18"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-github-pull-requests",
+    "exposedModules": {
+      "GithubPullRequestsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-github-pull-requests';

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-jira",
+  "version": "2.4.11",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-jira": "2.4.11"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-jira",
+    "exposedModules": {
+      "JiraPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-jira';

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/.eslintrc.js
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "roadiehq-backstage-plugin-security-insights",
+  "version": "2.3.9",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test --coverage",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin"
+  },
+  "dependencies": {
+    "@roadiehq/backstage-plugin-security-insights": "2.3.9"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
+  },
+  "files": [
+    "dist",
+    "dist-scalprum"
+  ],
+  "scalprum": {
+    "name": "roadiehq.backstage-plugin-security-insights",
+    "exposedModules": {
+      "SecurityInsightsPlugin": "./src/index.ts"
+    }
+  }
+}

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@roadiehq/backstage-plugin-security-insights';

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
@@ -33,7 +33,8 @@
     "@roadiehq/scaffolder-backend-argocd": "1.1.17"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
@@ -32,7 +32,8 @@
     "@roadiehq/scaffolder-backend-module-utils": "1.10.4"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.3.1"
+    "@backstage/cli": "0.23.1",
+    "@janus-idp/cli": "1.3.2"
   },
   "files": [
     "dist",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@backstage/test-utils": "1.4.4",
-    "@janus-idp/cli": "^1.3.1",
+    "@janus-idp/cli": "1.3.2",
     "@scalprum/react-test-utils": "0.0.5",
     "@testing-library/dom": "8.20.1",
     "@testing-library/jest-dom": "5.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,7 +1986,7 @@
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"
 
-"@backstage/backend-app-api@^0.5.6":
+"@backstage/backend-app-api@^0.5.5", "@backstage/backend-app-api@^0.5.6":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-0.5.7.tgz#ebc52710ea0b125734abc3a4f3832280501ff44e"
   integrity sha512-dnuYyqHfQTNAo+mq0mmsRDRu0AA48ExSs0alPAt2EnP/m3rfJakxOYMneb9Cr+aWralIdb7KE0N6oPDBaFe3Xg==
@@ -2022,7 +2022,7 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
-"@backstage/backend-common@0.19.8", "@backstage/backend-common@^0.19.0", "@backstage/backend-common@^0.19.4", "@backstage/backend-common@^0.19.6", "@backstage/backend-common@^0.19.8":
+"@backstage/backend-common@0.19.8", "@backstage/backend-common@^0.19.4", "@backstage/backend-common@^0.19.8":
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.19.8.tgz#df4cb4826edc8b60a74d34904eca349d913c257f"
   integrity sha512-MGHjuq35fX5fy7LVMUs6tIFeE9Hx1Ok8mrFxP15WbRWwSjHoXmEzjsQQzuw1xSviEHWupOAW7DevO+oZ5zgy1g==
@@ -2082,7 +2082,72 @@
     yauzl "^2.10.0"
     yn "^4.0.0"
 
-"@backstage/backend-dev-utils@^0.1.2":
+"@backstage/backend-common@^0.19.0", "@backstage/backend-common@^0.19.6":
+  version "0.19.7"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.19.7.tgz#69ec9e4ea8b75745e4a320711501b50604d8e049"
+  integrity sha512-0n52fRmakaeOH2nsTB13i2pbmxdcnzpGOxupYMlmwsaAiOnzKJ0Tu9FJCixwaCrg2EjL/AWh9BWthcNDFpduag==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-app-api" "^0.5.5"
+    "@backstage/backend-dev-utils" "^0.1.1"
+    "@backstage/backend-plugin-api" "^0.6.5"
+    "@backstage/cli-common" "^0.1.12"
+    "@backstage/config" "^1.1.0"
+    "@backstage/config-loader" "^1.5.0"
+    "@backstage/errors" "^1.2.2"
+    "@backstage/integration" "^1.7.0"
+    "@backstage/integration-aws-node" "^0.1.6"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/storage" "^6.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@kubernetes/client-node" "0.18.1"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@types/cors" "^2.8.6"
+    "@types/dockerode" "^3.3.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    "@types/webpack-env" "^1.15.2"
+    archiver "^5.0.2"
+    base64-stream "^1.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cors "^2.8.5"
+    dockerode "^3.3.1"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "10.1.0"
+    git-url-parse "^13.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^4.6.0"
+    keyv "^4.5.2"
+    knex "^2.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^5.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    mysql2 "^2.2.5"
+    node-fetch "^2.6.7"
+    node-forge "^1.3.1"
+    pg "^8.3.0"
+    raw-body "^2.4.1"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    tar "^6.1.12"
+    uuid "^8.3.2"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^2.10.0"
+    yn "^4.0.0"
+
+"@backstage/backend-dev-utils@^0.1.1", "@backstage/backend-dev-utils@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@backstage/backend-dev-utils/-/backend-dev-utils-0.1.2.tgz#357f2b669bed0452d9dca511e35a61071c57ea20"
   integrity sha512-R7ouSSSHDGMWVoME8DL4RtzUrKOVt6+NAo2EAO0EI3aWhm6IxHrLuYG8yTWEWrqUgTFAkaOwdknI/jbZwFwLUw==
@@ -2102,7 +2167,7 @@
     lodash "^4.17.21"
     openapi3-ts "^3.1.2"
 
-"@backstage/backend-plugin-api@0.6.6", "@backstage/backend-plugin-api@^0.6.6":
+"@backstage/backend-plugin-api@0.6.6", "@backstage/backend-plugin-api@^0.6.5", "@backstage/backend-plugin-api@^0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-0.6.6.tgz#55e0ee5f7685438d808bb3ae7351c0b74d1a707c"
   integrity sha512-dwTQ6ac/3h3MVJRlDP2qlluRFrWTnW+EWDgz4f1TKMK9lf13oQN6sDWOVi+e5bU+OrlqFIZx86ShiBky1SGOjg==
@@ -2177,7 +2242,7 @@
     winston "^3.2.1"
     zod "^3.21.4"
 
-"@backstage/catalog-client@1.4.5", "@backstage/catalog-client@^1.4.4", "@backstage/catalog-client@^1.4.5":
+"@backstage/catalog-client@1.4.5", "@backstage/catalog-client@^1.4.5":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.4.5.tgz#d104748fed1561ff6f6e77cb8de65e3b1182be9e"
   integrity sha512-WiCJPbIYBjR8GQ7NBW+n0fA3fFfYEs1s+7aYjPsO1YmDHJJfy3CbjNWrpDeo3snEuEXzTN6QONr/cSsvB6n8PA==
@@ -2186,7 +2251,16 @@
     "@backstage/errors" "^1.2.3"
     cross-fetch "^3.1.5"
 
-"@backstage/catalog-model@1.4.3", "@backstage/catalog-model@^1.4.2", "@backstage/catalog-model@^1.4.3":
+"@backstage/catalog-client@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.4.4.tgz#cb8be20a7365917dbf10db148a3306e500f33f5b"
+  integrity sha512-biYtZtXcdnuc3FV5hp6+8epklLeVknWOtY54ASxky+SJCsadBZ/tpU58KxW4pD92uPSVGiE7gaSBvvOaisyz0Q==
+  dependencies:
+    "@backstage/catalog-model" "^1.4.2"
+    "@backstage/errors" "^1.2.2"
+    cross-fetch "^3.1.5"
+
+"@backstage/catalog-model@1.4.3", "@backstage/catalog-model@^1.4.3":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.4.3.tgz#64abf34071d1cad6372f905b92e1d831e480750c"
   integrity sha512-cfbTPWLVma/ZKxRh76aLWqSFozzXMxHoGK+Tn50dOxHHp2xmdcx5jWBtOszNJs560rR7KScD7YnImUPkNn5DWQ==
@@ -2196,7 +2270,20 @@
     ajv "^8.10.0"
     lodash "^4.17.21"
 
-"@backstage/cli-common@^0.1.13":
+"@backstage/catalog-model@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.4.2.tgz#5e03a63a9d08e3f4d8b5fa0afc6e2b06c591551e"
+  integrity sha512-Mxa/Xcj2lheu2FYipdol2gkUHHf7+TjObh3cS6uf/xTyN+Pjym+j6xxPYeKzJ/X/tsPh5U2suvL75bV/jRlPsw==
+  dependencies:
+    "@backstage/config" "^1.1.0"
+    "@backstage/errors" "^1.2.2"
+    "@backstage/types" "^1.1.1"
+    ajv "^8.10.0"
+    json-schema "^0.4.0"
+    lodash "^4.17.21"
+    uuid "^8.0.0"
+
+"@backstage/cli-common@^0.1.12", "@backstage/cli-common@^0.1.13":
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.13.tgz#cbeda6a359ca4437fc782f0ac51bb957e8d49e73"
   integrity sha512-UMgNAIJSeEPSMkzxiWCP8aFR8APsG21XczDnzwHdL/41F7g2C+KA6UeQc/3tzbe8XQo+PxbNLpReZeKSSnSPSQ==
@@ -2330,7 +2417,7 @@
     yn "^4.0.0"
     zod "^3.21.4"
 
-"@backstage/config-loader@^1.5.1":
+"@backstage/config-loader@^1.5.0", "@backstage/config-loader@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@backstage/config-loader/-/config-loader-1.5.2.tgz#2cd808c941553bbb957c443fba7441075184d132"
   integrity sha512-yoN6UdzGeSU73A43FQMT2Rz2cJTnIy02bGvAnAFYvBXJHvn3WXlHAXxjeOvcm6KJfZImziVUO6Sujv1YM8WpKw==
@@ -2352,12 +2439,21 @@
     typescript-json-schema "^0.61.0"
     yaml "^2.0.0"
 
-"@backstage/config@1.1.1", "@backstage/config@^1.0.8", "@backstage/config@^1.1.0", "@backstage/config@^1.1.1":
+"@backstage/config@1.1.1", "@backstage/config@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.1.1.tgz#824ef3d74b391579060d5646fa1f45fcd553ce02"
   integrity sha512-H+xZbIVvstrkVnfxZFH6JB3Gb5qUIb8DjHOakHUlDX7xEIXjQnaM3Kf85RtnHu0uYpFIpB29i8FI68Y/uLeqyw==
   dependencies:
     "@backstage/errors" "^1.2.3"
+    "@backstage/types" "^1.1.1"
+    lodash "^4.17.21"
+
+"@backstage/config@^1.0.8", "@backstage/config@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.1.0.tgz#44eb90dbbc246f0c503260292dad63323325a581"
+  integrity sha512-E29BWXTKWBJ+o8MSHTTcOzCbgwoBDy2h3XZXrzexq2wz0Z5UVMYm3ukLesOL2C+U+Zpuz+ncdg63MWhNFHZqsA==
+  dependencies:
+    "@backstage/errors" "^1.2.2"
     "@backstage/types" "^1.1.1"
     lodash "^4.17.21"
 
@@ -2427,7 +2523,7 @@
     zen-observable "^0.10.0"
     zod "^3.21.4"
 
-"@backstage/core-plugin-api@1.7.0", "@backstage/core-plugin-api@^1.5.2", "@backstage/core-plugin-api@^1.6.0", "@backstage/core-plugin-api@^1.7.0":
+"@backstage/core-plugin-api@1.7.0", "@backstage/core-plugin-api@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.7.0.tgz#652ec473aa22d8dede35c90159284c522667ffb5"
   integrity sha512-nbwcC1BoS0y4mcVzGXtv6/JWkMT/6hvA91zHHGYkQ8bc0Gs6bHz/0AoSBTP8Rou+Dxf12ZYftuGCMbeQLz5s3Q==
@@ -2439,12 +2535,35 @@
     history "^5.0.0"
     i18next "^22.4.15"
 
-"@backstage/errors@^1.2.1", "@backstage/errors@^1.2.2", "@backstage/errors@^1.2.3":
+"@backstage/core-plugin-api@^1.5.2", "@backstage/core-plugin-api@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.6.0.tgz#15c30f01c79e82756e5c286675f8801195538afb"
+  integrity sha512-B3X9vJ8IRMY4+FCnWAgeYJhtcQJmoLvn6JzqilODtM70UfT2sBQ3UBMP/J4SPUMA15kbzi6D1x1BhHhkWd+A/w==
+  dependencies:
+    "@backstage/config" "^1.1.0"
+    "@backstage/types" "^1.1.1"
+    "@backstage/version-bridge" "^1.0.5"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    history "^5.0.0"
+    i18next "^22.4.15"
+    prop-types "^15.7.2"
+    zen-observable "^0.10.0"
+
+"@backstage/errors@^1.2.1", "@backstage/errors@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.3.tgz#6418d3ece63b13d14e32d44ec4db0f8866b0b1c9"
   integrity sha512-3YtYRKLNeRaSCzKSikNFoemesacDoEY0UwZAq7lnzCCpiCpSCfg7UA4y7wfjadFFU9Pd6nckUg2BzOk9keL15w==
   dependencies:
     "@backstage/types" "^1.1.1"
+    serialize-error "^8.0.1"
+
+"@backstage/errors@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.2.tgz#3494f848ccd8216a04e33b3b0bb058edfd293a17"
+  integrity sha512-heLY4f1OhfSGoSr/FHBJayudic6p8cnt6z5pZRjeT8yZdak7wiztpgN8AQFN1jZ+7VIvV80U0weTK3fgBIGWMw==
+  dependencies:
+    "@backstage/types" "^1.1.1"
+    cross-fetch "^3.1.5"
     serialize-error "^8.0.1"
 
 "@backstage/eslint-plugin@^0.1.3":
@@ -2486,7 +2605,7 @@
     zod "^3.21.4"
     zod-to-json-schema "^3.21.4"
 
-"@backstage/integration-aws-node@^0.1.7":
+"@backstage/integration-aws-node@^0.1.6", "@backstage/integration-aws-node@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@backstage/integration-aws-node/-/integration-aws-node-0.1.7.tgz#0ac74f2e570593bd3134a448d20c2006b4c407d1"
   integrity sha512-EoVoK3aD37puah5CKNe2ytcfq4wD838JPbpXpADqOS1bz45/938v1+a4bgtVO9tlewXuVFSQiFvRAJLg3/Fg3A==
@@ -2499,7 +2618,7 @@
     "@backstage/config" "^1.1.1"
     "@backstage/errors" "^1.2.3"
 
-"@backstage/integration-react@1.1.20", "@backstage/integration-react@^1.1.19", "@backstage/integration-react@^1.1.20":
+"@backstage/integration-react@1.1.20", "@backstage/integration-react@^1.1.20":
   version "1.1.20"
   resolved "https://registry.yarnpkg.com/@backstage/integration-react/-/integration-react-1.1.20.tgz#f2e6049494b3945cfc8588ec5641c4460ce967fa"
   integrity sha512-aJbCeU91wmhl+I2HgJFgKR3/QmCfIzzeF/bIcUwzYNbNuzgk+V8I7tizLumysjlt2iQT+6vsIscDMn5YTLki/w==
@@ -2511,13 +2630,44 @@
     "@material-ui/icons" "^4.9.1"
     "@types/react" "^16.13.1 || ^17.0.0"
 
-"@backstage/integration@1.7.1", "@backstage/integration@^1.5.0", "@backstage/integration@^1.7.1":
+"@backstage/integration-react@^1.1.19":
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/@backstage/integration-react/-/integration-react-1.1.19.tgz#257fbed733ab7b80939ae947283d0f9e895c6fad"
+  integrity sha512-Pz7sr27BKONwvd2gjgHk1cfaThfMJUgD1QiJxTZWBnI+oWBu+UWMYbFQtkavQceTkxaZU0aPLzupfuZ4FR//vg==
+  dependencies:
+    "@backstage/config" "^1.1.0"
+    "@backstage/core-components" "^0.13.5"
+    "@backstage/core-plugin-api" "^1.6.0"
+    "@backstage/integration" "^1.7.0"
+    "@backstage/theme" "^0.4.2"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.61"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    react-use "^17.2.4"
+
+"@backstage/integration@1.7.1", "@backstage/integration@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.7.1.tgz#dc951c5d1154ac9761224936d58dda95f9ffa1f0"
   integrity sha512-pUKfiNHaBFCSZnNWJ+E8kDAHwDtTs/zXvEij+thARluXt+AIptFs9QfV9d8hidcgKlKV3+oUbu39M9798CgRFg==
   dependencies:
     "@azure/identity" "^3.2.1"
     "@backstage/config" "^1.1.1"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^3.1.5"
+    git-url-parse "^13.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
+"@backstage/integration@^1.5.0", "@backstage/integration@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.7.0.tgz#8f398411c13a87c94f1550f9b9e454d79c3780ed"
+  integrity sha512-zDvuTuCVAQB1KziEp/9gWBTO0ZycFGmIjENbe1Xv7tYAW9tlQU0BORvyI9QqKk3LXn73+a/3MNNZ5noogxvDDA==
+  dependencies:
+    "@azure/identity" "^3.2.1"
+    "@backstage/config" "^1.1.0"
+    "@backstage/errors" "^1.2.2"
     "@octokit/auth-app" "^4.0.0"
     "@octokit/rest" "^19.0.3"
     cross-fetch "^3.1.5"
@@ -2898,7 +3048,7 @@
     yn "^4.0.0"
     zod "^3.21.4"
 
-"@backstage/plugin-catalog-common@1.0.17", "@backstage/plugin-catalog-common@^1.0.17":
+"@backstage/plugin-catalog-common@1.0.17", "@backstage/plugin-catalog-common@^1.0.16", "@backstage/plugin-catalog-common@^1.0.17":
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.17.tgz#c7347f6fecc8237d2042c73a516ae8b743345b35"
   integrity sha512-/oP8/3Kzqks09ZO/sfO/fgl7bnt8jcQCBfTYEYGaCUkRTdH6xLRx+hLkdImBfUEGpe5y48LnS7qmfblkVqHsDw==
@@ -2968,7 +3118,7 @@
     "@backstage/plugin-catalog-common" "^1.0.17"
     "@backstage/types" "^1.1.1"
 
-"@backstage/plugin-catalog-react@1.8.5", "@backstage/plugin-catalog-react@^1.7.0", "@backstage/plugin-catalog-react@^1.8.4", "@backstage/plugin-catalog-react@^1.8.5":
+"@backstage/plugin-catalog-react@1.8.5", "@backstage/plugin-catalog-react@^1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-1.8.5.tgz#de0632947147378f74139b59e136049b178c81ab"
   integrity sha512-S9krXFdEt/BukrcbO4e4iCaRAH0ADcVFuO8uQ2JfK5s9s+pUUv+NKEGx0j3Gr+BR5lEZXivoMdsiDrzbFFiSkg==
@@ -2991,6 +3141,37 @@
     "@react-hookz/web" "^23.0.0"
     "@types/react" "^16.13.1 || ^17.0.0"
     classnames "^2.2.6"
+    lodash "^4.17.21"
+    material-ui-popup-state "^1.9.3"
+    qs "^6.9.4"
+    react-use "^17.2.4"
+    yaml "^2.0.0"
+    zen-observable "^0.10.0"
+
+"@backstage/plugin-catalog-react@^1.7.0", "@backstage/plugin-catalog-react@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-1.8.4.tgz#9e47f642218c449b673bfccedf001fb6f7c526be"
+  integrity sha512-oi+9ghMsi4e3/koS3Am0Tx0N2sv+aEpsME6gBDwFKgeLU19xGvewLdnzSF0zftWbG63OgZJdZsuK+JGLU7giMw==
+  dependencies:
+    "@backstage/catalog-client" "^1.4.4"
+    "@backstage/catalog-model" "^1.4.2"
+    "@backstage/core-components" "^0.13.5"
+    "@backstage/core-plugin-api" "^1.6.0"
+    "@backstage/errors" "^1.2.2"
+    "@backstage/integration" "^1.7.0"
+    "@backstage/plugin-catalog-common" "^1.0.16"
+    "@backstage/plugin-permission-common" "^0.7.8"
+    "@backstage/plugin-permission-react" "^0.4.15"
+    "@backstage/theme" "^0.4.2"
+    "@backstage/types" "^1.1.1"
+    "@backstage/version-bridge" "^1.0.5"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.61"
+    "@react-hookz/web" "^23.0.0"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    classnames "^2.2.6"
+    jwt-decode "^3.1.0"
     lodash "^4.17.21"
     material-ui-popup-state "^1.9.3"
     qs "^6.9.4"
@@ -3429,7 +3610,7 @@
     yn "^4.0.0"
     zod "^3.21.4"
 
-"@backstage/plugin-permission-common@0.7.9", "@backstage/plugin-permission-common@^0.7.7", "@backstage/plugin-permission-common@^0.7.9":
+"@backstage/plugin-permission-common@0.7.9", "@backstage/plugin-permission-common@^0.7.7", "@backstage/plugin-permission-common@^0.7.8", "@backstage/plugin-permission-common@^0.7.9":
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.7.9.tgz#ea4401b7160f3f3f2cc075b691d1594d9560183c"
   integrity sha512-8/yrybvyEYkSkSnk/7NMNjqBkgvl0yj1VI8jJydYgIBoZj93V7qsaYfGEfpf1Af0NYDoTgPS2vI4lz0jB1RMKg==
@@ -3466,6 +3647,19 @@
     "@backstage/config" "^1.1.1"
     "@backstage/core-plugin-api" "^1.7.0"
     "@backstage/plugin-permission-common" "^0.7.9"
+    "@types/react" "^16.13.1 || ^17.0.0"
+    cross-fetch "^3.1.5"
+    react-use "^17.2.4"
+    swr "^2.0.0"
+
+"@backstage/plugin-permission-react@^0.4.15":
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-react/-/plugin-permission-react-0.4.15.tgz#fc6ea35f9b7818f1905e060321a8828b9f4467ee"
+  integrity sha512-vk0YnH2YNVHPFWsE+4m+9F8Hbf9yQwRTMcuDItkuP/QyzKo5xcNpbrFJrnyx8KB4BA7rIesXeZ3jVKXBoqIflw==
+  dependencies:
+    "@backstage/config" "^1.1.0"
+    "@backstage/core-plugin-api" "^1.6.0"
+    "@backstage/plugin-permission-common" "^0.7.8"
     "@types/react" "^16.13.1 || ^17.0.0"
     cross-fetch "^3.1.5"
     react-use "^17.2.4"
@@ -4084,7 +4278,7 @@
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.1.1.tgz#c9ccb30357005e7fb5fa2ac140198059976eb076"
   integrity sha512-1cUGu+FwiJZCBOuecd0BOhIRkQYllb+7no9hHhxpAsx/DvsPGMVQMGOMvtdTycdT9SQ5MuSyFwI9wpXp2DwVvQ==
 
-"@backstage/version-bridge@^1.0.6":
+"@backstage/version-bridge@^1.0.5", "@backstage/version-bridge@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@backstage/version-bridge/-/version-bridge-1.0.6.tgz#87ec80d930421f44c0554e226fc2d9282c2f5358"
   integrity sha512-30bYWdbggedNMZ08JPIu/CXhmzSxORA2qcgyd1vbbndjYpWEmOJr4G7THO2EAM8eYk90eENVvL49i7dkGvFnJg==
@@ -5427,10 +5621,72 @@
     lodash "^4.17.21"
     react-use "^17.4.0"
 
-"@janus-idp/cli@1.3.1", "@janus-idp/cli@^1.3.1":
+"@janus-idp/cli@1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.3.1.tgz#8272576a20ec88241c082d233f0a6d0e29cae77e"
   integrity sha512-1GRfojww/cj3J0eNV3a6c7xE13f4HjqDb4ad0O2wirRfzY3aBvCl1/nCucmReYtpBI5TuQPmDL8O8S+7IixhBQ==
+  dependencies:
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/cli-node" "^0.1.5"
+    "@backstage/config" "^1.1.1"
+    "@backstage/config-loader" "^1.5.1"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/eslint-plugin" "^0.1.3"
+    "@backstage/types" "^1.1.1"
+    "@manypkg/get-packages" "^1.1.3"
+    "@openshift/dynamic-plugin-sdk-webpack" "^3.0.0"
+    "@pmmmwh/react-refresh-webpack-plugin" "^0.5.7"
+    "@rollup/plugin-commonjs" "^25.0.4"
+    "@rollup/plugin-json" "^6.0.0"
+    "@rollup/plugin-node-resolve" "^15.2.1"
+    "@rollup/plugin-yaml" "^4.0.0"
+    "@svgr/rollup" "^8.1.0"
+    "@svgr/webpack" "^6.5.1"
+    "@yarnpkg/lockfile" "^1.1.0"
+    "@yarnpkg/parsers" "^3.0.0-rc.4"
+    bfj "^7.0.2"
+    chalk "^4.0.0"
+    chokidar "^3.3.1"
+    commander "^9.1.0"
+    css-loader "^6.5.1"
+    esbuild "^0.19.0"
+    esbuild-loader "^2.18.0"
+    eslint "^8.49.0"
+    eslint-config-prettier "^8.10.0"
+    eslint-webpack-plugin "^3.2.0"
+    express "^4.18.2"
+    fork-ts-checker-webpack-plugin "^7.0.0-alpha.8"
+    fs-extra "^10.1.0"
+    handlebars "^4.7.7"
+    html-webpack-plugin "^5.3.1"
+    inquirer "^8.2.0"
+    lodash "^4.17.21"
+    mini-css-extract-plugin "^2.4.2"
+    node-libs-browser "^2.2.1"
+    npm-packlist "^5.0.0"
+    ora "^5.3.0"
+    postcss "^8.2.13"
+    process "^0.11.10"
+    react-dev-utils "^12.0.0-next.60"
+    react-refresh "^0.14.0"
+    recursive-readdir "^2.2.2"
+    rollup "^2.78.0"
+    rollup-plugin-dts "^4.0.1"
+    rollup-plugin-esbuild "^4.7.2"
+    rollup-plugin-postcss "^4.0.0"
+    rollup-pluginutils "^2.8.2"
+    semver "^7.5.4"
+    style-loader "^3.3.1"
+    swc-loader "^0.2.3"
+    webpack "^5.89.0"
+    webpack-dev-server "^4.15.1"
+    yml-loader "^2.1.0"
+    yn "^4.0.0"
+
+"@janus-idp/cli@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.3.2.tgz#e659eaf71c12c125047968650b6f047f58b76ef7"
+  integrity sha512-AmzLlxUpZ2RGoGC5GKJ5JZ/mSUrEf5vpwpu6/V73i+dyyLnV3c28JFE+WwW9b4CRN7b2yzkjFxplc302JoI72g==
   dependencies:
     "@backstage/cli-common" "^0.1.13"
     "@backstage/cli-node" "^0.1.5"
@@ -5837,6 +6093,30 @@
     ajv-formats "^2.1.1"
     ajv-formats-draft2019 "^1.6.1"
     tslib "^2.4.0"
+
+"@kubernetes/client-node@0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.18.1.tgz#58d864c8f584efd0f8670f6c46bb8e9d5abd58f6"
+  integrity sha512-F3JiK9iZnbh81O/da1tD0h8fQMi/MDttWc/JydyUVnjPEom55wVfnpl4zQ/sWD4uKB8FlxYRPiLwV2ZXB+xPKw==
+  dependencies:
+    "@types/js-yaml" "^4.0.1"
+    "@types/node" "^18.11.17"
+    "@types/request" "^2.47.1"
+    "@types/ws" "^8.5.3"
+    byline "^5.0.0"
+    isomorphic-ws "^5.0.0"
+    js-yaml "^4.1.0"
+    jsonpath-plus "^7.2.0"
+    request "^2.88.0"
+    rfc4648 "^1.3.0"
+    stream-buffers "^3.0.2"
+    tar "^6.1.11"
+    tmp-promise "^3.0.2"
+    tslib "^2.4.1"
+    underscore "^1.13.6"
+    ws "^8.11.0"
+  optionalDependencies:
+    openid-client "^5.3.0"
 
 "@kubernetes/client-node@0.19.0", "@kubernetes/client-node@^0.19.0":
   version "0.19.0"
@@ -7259,9 +7539,9 @@
     tslib "^2.4.1"
 
 "@segment/analytics-next@^1.58.0":
-  version "1.58.0"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.58.0.tgz#c5c0c6ad65f21b0ea607c32b168f1d88aab1a21e"
-  integrity sha512-Wh+/D3QsjbO42N6O542FCf74wnL5JMj9HWq309NGcNbjo7WwIGHOHgE+tUFm1b0CsBL5zWI+mGJBU+U6PBaNWw==
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-next/-/analytics-next-1.59.0.tgz#5d0282d32157fd927399af34d32e66eae35b2e53"
+  integrity sha512-1DE95SSJ6pS1t8tshoo5B2qOrzM4ede1JIxXoaiCG475xG5h2bVMXWoKayZ2Hh3vU9te3ZFV/kOMkS32vLDaUA==
   dependencies:
     "@lukeed/uuid" "^2.0.0"
     "@segment/analytics-core" "1.3.2"
@@ -9906,9 +10186,9 @@
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33", "@types/express-serve-static-core@^4.17.5":
-  version "4.17.39"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz#2107afc0a4b035e6cb00accac3bdf2d76ae408c8"
-  integrity sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==
+  version "4.17.37"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz#7e4b7b59da9142138a2aaa7621f5abedce8c7320"
+  integrity sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -10027,9 +10307,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@*", "@types/jest@^29.0.0":
-  version "29.5.6"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.6.tgz#f4cf7ef1b5b0bfc1aa744e41b24d9cc52533130b"
-  integrity sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==
+  version "29.5.5"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.5.tgz#727204e06228fe24373df9bae76b90f3e8236a2a"
+  integrity sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -10205,6 +10485,13 @@
   version "16.18.59"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.59.tgz#4cdbd631be6d9be266a96fb17b5d0d7ad6bbe26c"
   integrity sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==
+
+"@types/node@^18.11.17":
+  version "18.18.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.8.tgz#2b285361f2357c8c8578ec86b5d097c7f464cfd6"
+  integrity sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^18.11.18":
   version "18.18.6"
@@ -10496,9 +10783,9 @@
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/webpack-env@^1.15.2":
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.3.tgz#e81f769199a5609c751f34fcc6f6095ceac7831f"
-  integrity sha512-v4CH6FLBCftYGFAswDhzFLjKgucXsOkIf5Mzl8ZZhEtC6oye9whFInNPKszNB9AvX7JEZMtpXxWctih6addP+Q==
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.18.2.tgz#0264bc30c0c4a073118ce5b26c5ef143da4374df"
+  integrity sha512-BFqcTHHTrrI8EBmIzNAmLPP3IqtEG9J1IPFWbPeS/F0/TGNmo0pI5svOa7JbMF9vSCXQCvJWT2gxLJNVuf9blw==
 
 "@types/ws@^8.5.3", "@types/ws@^8.5.5":
   version "8.5.8"
@@ -13618,9 +13905,9 @@ core-js-compat@^3.31.0, core-js-compat@^3.32.2:
     browserslist "^4.22.1"
 
 core-js-pure@^3.23.3, core-js-pure@^3.30.2, core-js-pure@^3.6.5:
-  version "3.33.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.33.1.tgz#7f27dd239da8eb97dbea30120071be8e5565cb0e"
-  integrity sha512-wCXGbLjnsP10PlK/thHSQlOLlLKNEkaWbTzVvHHZ79fZNeN1gUmw2gBlpItxPv/pvqldevEXFh/d5stdNvl6EQ==
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.33.0.tgz#938a28754b4d82017a7a8cbd2727b1abecc63591"
+  integrity sha512-FKSIDtJnds/YFIEaZ4HszRX7hkxGpNKM7FC9aJ9WLJbSd3lD4vOltFuVIBLR8asSx9frkTSqL0dw90SKQxgKrg==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
@@ -13765,7 +14052,12 @@ cron@^2.0.0:
     "@types/luxon" "~3.3.0"
     luxon "~3.3.0"
 
-cronstrue@^2.2.0, cronstrue@^2.32.0:
+cronstrue@^2.2.0:
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.32.0.tgz#cb705bdd9ba76d5fd64be4e1df1f2eee7165dad9"
+  integrity sha512-dmNflOCNJL6lZEj0dp2YhGIPY83VTjFue6d9feFhnNtrER6mAjBrUvSgK95j3IB/xNGpLjaZDIDG6ACKTZr9Yw==
+
+cronstrue@^2.32.0:
   version "2.41.0"
   resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.41.0.tgz#bef0439e433dfe37bc5efbe4512bc773bd8d97f9"
   integrity sha512-3ZS3eMJaxMRBGmDauKCKbyIRgVcph6uSpkhSbbZvvJWkelHiSTzGJbBqmu8io7Hspd2F45bQKnC1kzoNvtku2g==
@@ -16402,7 +16694,12 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.1, function-bind@^1.1.2:
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
@@ -16918,9 +17215,11 @@ has-unicode@^2.0.1:
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
 
 has@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
-  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -24821,9 +25120,9 @@ terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
     terser "^5.16.8"
 
 terser@^5.10.0, terser@^5.16.8:
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.22.0.tgz#4f18103f84c5c9437aafb7a14918273310a8a49d"
-  integrity sha512-hHZVLgRA2z4NWcN6aS5rQDc+7Dcy58HOf2zbYwmFcQ+ua3h6eEFf5lIDKTzbWwlazPyOZsFQO8V80/IjVNExEw==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.20.0.tgz#ea42aea62578703e33def47d5c5b93c49772423e"
+  integrity sha512-e56ETryaQDyebBwJIWYB2TT6f2EZ0fL0sW/JRXNMN26zZdKi2u/E/5my5lG6jNxym6qsrVXfFRmOdV42zlAgLQ==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -24922,6 +25221,13 @@ tiny-warning@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -24929,7 +25235,7 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.2.1:
+tmp@^0.2.0, tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
@@ -25470,7 +25776,7 @@ underscore@1.12.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
   integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
-underscore@^1.12.1, underscore@~1.13.2:
+underscore@^1.12.1, underscore@^1.13.6, underscore@~1.13.2:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
@@ -26267,10 +26573,40 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.0.0, webpack@^5.70.0, webpack@^5.89.0:
+webpack@^5.0.0, webpack@^5.89.0:
   version "5.89.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.89.0.tgz#56b8bf9a34356e93a6625770006490bf3a7f32dc"
   integrity sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^1.0.0"
+    "@webassemblyjs/ast" "^1.11.5"
+    "@webassemblyjs/wasm-edit" "^1.11.5"
+    "@webassemblyjs/wasm-parser" "^1.11.5"
+    acorn "^8.7.1"
+    acorn-import-assertions "^1.9.0"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.15.0"
+    es-module-lexer "^1.2.1"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.2.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.3.7"
+    watchpack "^2.4.0"
+    webpack-sources "^3.2.3"
+
+webpack@^5.70.0:
+  version "5.88.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.88.2.tgz#f62b4b842f1c6ff580f3fcb2ed4f0b579f4c210e"
+  integrity sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"


### PR DESCRIPTION
## Description

Add a dynamic plugin wrapper for frontend plugins we consume from upstream.

Similar to the backend plugins, with the only change that we do not need to additional code/interface, we just reexport the original plugin with additional metadata in `package.json`.

None of these plugins are consumed by the instance by default. This just creates all the necessary wrappers.

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
