### PR TITLE
Add a dynamic-plugin-aware `PluginIDProvider`

### DIFF
--- a/.changeset/nervous-mangos-protect.md
+++ b/.changeset/nervous-mangos-protect.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Add RBAC permission policy retrieval for backend dynamic plugins.

--- a/packages/backend/src/plugins/permission.ts
+++ b/packages/backend/src/plugins/permission.ts
@@ -1,16 +1,23 @@
 import type { Router } from 'express';
 import type { PluginEnvironment } from '../types';
-import { PolicyBuilder } from '@janus-idp/backstage-plugin-rbac-backend';
+import {
+  PolicyBuilder,
+  PluginIdProvider,
+} from '@janus-idp/backstage-plugin-rbac-backend';
 
 export default async function createPlugin(
   env: PluginEnvironment,
+  pluginIdProvider?: PluginIdProvider | undefined,
 ): Promise<Router> {
-  return await PolicyBuilder.build({
-    config: env.config,
-    logger: env.logger,
-    discovery: env.discovery,
-    identity: env.identity,
-    permissions: env.permissions,
-    tokenManager: env.tokenManager,
-  });
+  return await PolicyBuilder.build(
+    {
+      config: env.config,
+      logger: env.logger,
+      discovery: env.discovery,
+      identity: env.identity,
+      permissions: env.permissions,
+      tokenManager: env.tokenManager,
+    },
+    pluginIdProvider,
+  );
 }


### PR DESCRIPTION
## Description

Add a dynamic-plugin-aware `PluginIDProvider` to allow the RBAC plugin to grab the pluginIDs of backend dynamic plugins.

## Which issue(s) does this PR fix

- Fixes #623

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
