### PR TITLE
fix: disable cache for injected file.

### DIFF
--- a/.changeset/old-fans-work.md
+++ b/.changeset/old-fans-work.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Never cache the static Javascript asset that contains the injected server-side merged configuration.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,8 @@
     "pg": "8.11.3",
     "prom-client": "15.0.0",
     "winston": "3.11.0",
-    "fs-extra": "10.1.0"
+    "fs-extra": "10.1.0",
+    "express-rate-limit": "^7.1.3"
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,11 +49,13 @@
     "isolated-vm": "4.6.0",
     "pg": "8.11.3",
     "prom-client": "15.0.0",
-    "winston": "3.11.0"
+    "winston": "3.11.0",
+    "fs-extra": "10.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
     "@types/express": "4.17.20",
+    "@types/fs-extra": "9.0.11",
     "cross-env": "7.0.3"
   },
   "files": [

--- a/packages/backend/src/plugins/app.ts
+++ b/packages/backend/src/plugins/app.ts
@@ -1,14 +1,57 @@
 import { createRouter } from '@backstage/plugin-app-backend';
-import type { Router } from 'express';
+import { Router } from 'express';
 import type { PluginEnvironment } from '../types';
+import { resolvePackagePath } from '@backstage/backend-common';
+import { resolve as resolvePath } from 'path';
+import fs from 'fs-extra';
 
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
-  return await createRouter({
+  const appPackageName = 'app';
+
+  const appDistDir = resolvePackagePath(appPackageName, 'dist');
+  const staticDir = resolvePath(appDistDir, 'static');
+
+  const files = await fs.readdir(staticDir);
+  const jsFiles = files.filter(file => file.endsWith('.js'));
+  let injectedJSFile: string | undefined = undefined;
+
+  for (const jsFile of jsFiles) {
+    const path = resolvePath(staticDir, jsFile);
+
+    const content = await fs.readFile(path, 'utf8');
+    if (content.includes('__APP_INJECTED_')) {
+      injectedJSFile = jsFile;
+      break;
+    }
+  }
+
+  const router = await createRouter({
     logger: env.logger,
     config: env.config,
     database: env.database,
-    appPackageName: 'app',
+    appPackageName,
   });
+
+  const enclosingRouter = Router();
+  if (injectedJSFile) {
+    env.logger.info(
+      `Setting up static router for injected Javascript file ${injectedJSFile}`,
+    );
+
+    enclosingRouter.get(`/static/${injectedJSFile}`, (_req, res) => {
+      env.logger.info(
+        `Serving in the injected Javascript file with caching disabled`,
+      );
+      res.sendFile(resolvePath(staticDir, injectedJSFile!), {
+        headers: {
+          'cache-control': 'no-store, max-age=0',
+        },
+      });
+    });
+  }
+
+  enclosingRouter.use(router);
+  return enclosingRouter;
 }

--- a/packages/backend/src/plugins/app.ts
+++ b/packages/backend/src/plugins/app.ts
@@ -46,7 +46,7 @@ export default async function createPlugin(
       );
       res.sendFile(resolvePath(staticDir, injectedJSFile!), {
         headers: {
-          'cache-control': 'no-store, max-age=0',
+          'cache-control': 'no-cache',
         },
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16146,6 +16146,11 @@ express-promise-router@4.1.1, express-promise-router@^4.1.0, express-promise-rou
     lodash.flattendeep "^4.0.0"
     methods "^1.0.0"
 
+express-rate-limit@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.1.3.tgz#0eae6c7733316f3d9403a71ad488e31e94ca0aa4"
+  integrity sha512-BDes6WeNYSGRRGQU8QDNwUnwqaBro28HN/TTweM3RlxXRHDld8RLoH7tbfCxAc0hamQyn6aL0KrfR45+ZxknYg==
+
 express-session@^1.17.1:
   version "1.17.3"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.3.tgz#14b997a15ed43e5949cb1d073725675dd2777f36"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10210,6 +10210,13 @@
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.12.tgz#0307536218d32e6b970bccd1d148b9c4e5b6f10d"
   integrity sha512-uK2z1ZHJyC0nQRbuovXFt4mzXDwf27vQeUWNhfKGwRcWW429GOhP8HxUHlM6TLH4bzmlv/HlEjpvJh3JfmGsAA==
 
+"@types/fs-extra@9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.11.tgz#8cc99e103499eab9f347dbc6ca4e99fb8d2c2b87"
+  integrity sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"


### PR DESCRIPTION
## Description

Backend merged config is injected by the `app-backend` upstream plugin inside one of the Javascript
static assets before service static assets.
So we should never allow this specific JS file to be cached on the client side,
so that any change in the configuration can be seen on the frontend
side after a backend restart.
That's particularly critical to get the latest UI configuration
of added dynamic frontend plugins.

## Which issue(s) does this PR fix

- Fixes No issue number.

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
