### PR TITLE
fix(dynamic-plugins): handle plugin initialization failures

### DIFF
--- a/.changeset/breezy-trainers-do.md
+++ b/.changeset/breezy-trainers-do.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Add extra error handling while initializing dynamic front-end plugins. If a plugin fails to initialize, it won't be registered and won't be rendered at the expected place.

--- a/packages/app/src/components/DynamicRoot/Loader.tsx
+++ b/packages/app/src/components/DynamicRoot/Loader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+
+const Loader = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: 'calc(100vw - 16px)',
+        height: 'calc(100vh - 16px)',
+        backgroundColor: '#F8F8F8',
+      }}
+    >
+      <CircularProgress />
+    </Box>
+  );
+};
+
+export default Loader;


### PR DESCRIPTION
## Description

Add extra error handling while initializing dynamic front-end plugins. If a plugin fails to initialize, it won't be registered and won't be rendered at the expected place.

