### PR TITLE
chore: don't run scripts on dynamic plugin install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,6 +134,9 @@ USER 1001
 # https://github.com/backstage/backstage/issues/20644
 ENV CHOKIDAR_USEPOLLING='1' CHOKIDAR_INTERVAL='10000'
 
+# To avoid running scripts when using `npm pack` to install dynamic plugins
+ENV NPM_CONFIG_ignore-scripts='true'
+
 ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here

--- a/docker/brew.Dockerfile
+++ b/docker/brew.Dockerfile
@@ -223,6 +223,9 @@ USER 1001
 # https://github.com/backstage/backstage/issues/20644
 ENV CHOKIDAR_USEPOLLING='1' CHOKIDAR_INTERVAL='10000'
 
+# To avoid running scripts when using `npm pack` to install dynamic plugins
+ENV NPM_CONFIG_ignore-scripts='true'
+
 ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here


### PR DESCRIPTION
Don't run package scripts (`prepack`, `postpack` foe example) when using `npm pack` at runtime to install the dynamic plugins.

In fact that's also quite expected that no arbitrary script would be run while installing downloaded dynamic plugins.