### PR TITLE
chore: revert `yarn start` script

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
   },
   "//": "The extra configuration options in the start script are needed for local development",
   "scripts": {
-    "start": "cross-env LEGACY_BACKEND_START=true backstage-cli package start --config ../../app-config.yaml --config ../../app-config.example.yaml",
+    "start": "cross-env LEGACY_BACKEND_START=true backstage-cli package start",
     "build": "backstage-cli package build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",


### PR DESCRIPTION
## Description

Reverts the `yarn start` script to no longer load the `app-config.example.yaml` file for local development

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
