### PR TITLE
fix: removes tekton tab

### DIFF
--- a/.changeset/real-boxes-clap.md
+++ b/.changeset/real-boxes-clap.md
@@ -1,0 +1,5 @@
+---
+'app': minor
+---
+
+Removes Tekton tab

--- a/packages/app/src/components/catalog/EntityPage/index.tsx
+++ b/packages/app/src/components/catalog/EntityPage/index.tsx
@@ -195,12 +195,6 @@ export const entityPage = (
     })}
 
     {tab({
-      path: '/tekton',
-      title: 'Tekton',
-      mountPoint: 'entity.page.tekton',
-    })}
-
-    {tab({
       path: '/image-registry',
       title: 'Image Registry',
       mountPoint: 'entity.page.image-registry',

--- a/showcase-docs/dynamic-plugins.md
+++ b/showcase-docs/dynamic-plugins.md
@@ -529,7 +529,6 @@ The following mount points are available:
 | `entity.page.ci`             | Catalog entity "CI" tab             | NO                                                             |
 | `entity.page.cd`             | Catalog entity "CD" tab             | NO                                                             |
 | `entity.page.kubernetes`     | Catalog entity "Kubernetes" tab     | NO                                                             |
-| `entity.page.tekton`         | Catalog entity "Tekton" tab         | NO                                                             |
 | `entity.page.image-registry` | Catalog entity "Image Registry" tab | NO                                                             |
 | `entity.page.monitoring`     | Catalog entity "Monitoring" tab     | NO                                                             |
 | `entity.page.lighthouse`     | Catalog entity "Lighthouse" tab     | NO                                                             |


### PR DESCRIPTION
## Description

The dedicated tekon tab is no longer needed as it will only be shown on the CI tab

## Which issue(s) does this PR fix

- Fixes https://github.com/janus-idp/backstage-showcase/issues/718

## Screenshots

<img width="1721" alt="image" src="https://github.com/janus-idp/backstage-showcase/assets/5129024/3c497c00-f1d5-49e6-9b40-d21fa923762e">



## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
