### PR TITLE
chore(ci): trigger the Main Job for all changes

### DIFF
--- a/.changeset/perfect-balloons-repeat.md
+++ b/.changeset/perfect-balloons-repeat.md
@@ -1,5 +1,4 @@
 ---
-
 ---
 
 Update and complete the documentation related to dynamic plugins.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,6 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'showcase-docs/**'
-      - '.changeset/**'
     branches-ignore:
       - 'changeset-release/**'
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
## Description

Stop ignoring docs changes from triggering "Main Job"

the "Main Job" is configured as required check-in GitHub. When it is not triggered the docs-only PRs can't be merged without admin override.




## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
