### PR TITLE
fix: the Loader component to respect theme

### DIFF
--- a/.changeset/six-toys-give.md
+++ b/.changeset/six-toys-give.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Initial app <Loader /> component should respect Backstage theme even before Backstage context is loaded

--- a/packages/app/src/components/DynamicRoot/Loader.tsx
+++ b/packages/app/src/components/DynamicRoot/Loader.tsx
@@ -1,21 +1,41 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { customDarkTheme } from '../../themes/darkTheme';
+import { customLightTheme } from '../../themes/lightTheme';
+
+const themeLight = createTheme({
+  palette: customLightTheme({}).getTheme('v5')?.palette,
+});
+
+const themeDark = createTheme({
+  palette: customDarkTheme({}).getTheme('v5')?.palette,
+});
 
 const Loader = () => {
+  // Hack access theme context before Backstage App is even instantiated
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    setTheme(prevTheme => localStorage.getItem('theme') || prevTheme);
+  }, [theme]);
+
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: 'calc(100vw - 16px)',
-        height: 'calc(100vh - 16px)',
-        backgroundColor: '#F8F8F8',
-      }}
-    >
-      <CircularProgress />
-    </Box>
+    <ThemeProvider theme={theme === 'dark' ? themeDark : themeLight}>
+      <CssBaseline />
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '100vh',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    </ThemeProvider>
   );
 };
 


### PR DESCRIPTION
## Description

I've noticed our `Loader` component doesn't respect the user-selected Backstage theme. For a loader component this is especially hard since it is displayed before and during initial Backstage app context load and instantiation. This PR works around it by accessing the selected theme context from browser local storage and applies a theme subset that doesn't require Backstage APIs to be available.

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
