### PR TITLE
fix: increase max entry size for dynamic plugins

### DIFF
--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -29,7 +29,7 @@ import binascii
 # the dynamic plugins will be installed.
 #
 # Additionally, the MAX_ENTRY_SIZE environment variable can be defined to set
-# the maximum size of a file in the archive (default: 10MB).
+# the maximum size of a file in the archive (default: 20MB).
 #
 # The SKIP_INTEGRITY_CHECK environment variable can be defined with ("true") to skip the integrity check of remote packages
 #
@@ -112,7 +112,7 @@ def verify_package_integrity(plugin: dict, archive: str, working_directory: str)
 
 def main():
     dynamicPluginsRoot = sys.argv[1]
-    maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 10000000))
+    maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 20000000))
     skipIntegrityCheck = os.environ.get("SKIP_INTEGRITY_CHECK", "").lower() == "true"
 
     dynamicPluginsFile = 'dynamic-plugins.yaml'


### PR DESCRIPTION
## Description of the change

Increase max entry size for dynamic plugins in order to avoid triggering a zip-bomb error during installation for plugins delivered as part of the showcase docker image.

The previous value (10000000) was not enough for 2 of the plugins delivered as part of the showcase docker image (tekton plugin and the topology plugin)
## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
