### PR TITLE
fix: use the 'tar' filter to remove warnings

### DIFF
--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -268,7 +268,7 @@ def main():
                 if not realpath.startswith(directoryRealpath):
                   raise InstallException('NPM package archive contains a link outside of the archive: ' + member.name + ' -> ' + member.linkpath)
 
-                file.extract(member, path=directory)
+                file.extract(member, path=directory, filter='tar')
             else:
               if member.type == tarfile.CHRTYPE:
                   type_str = "character device"


### PR DESCRIPTION
## Description

Since recently on both docker images, which have been updated, the following warning is displayed in the initContainer logs during dynamic plugins installation:
```
==> Extracting package archive /dynamic-plugins-root/janus-idp-backstage-plugin-topology-1.16.4.tgz
/usr/lib64/python3.9/tarfile.py:2239: RuntimeWarning: The default behavior of tarfile extraction has been changed to disallow common exploits (including CVE-2007-4559). By default, absolute/parent paths are disallowed and some mode bits are cleared. See https://access.redhat.com/articles/7004769 for more details.
```

This is because a new `filter` option option has been added in the python `tar` library, whose default value changes the default behavior of the library.

Explicitely setting this filter option to `tar` (which is the new default) should remove the warning from the logs.

## Which issue(s) does this PR fix

No issue

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
