### PR TITLE
chore: shell script to install dynamic plugins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,8 +110,9 @@ COPY --from=cleanup --chown=1001:1001 $CONTAINER_SOURCE/ ./
 COPY --from=build $CONTAINER_SOURCE/dynamic-plugins/dist/ ./dynamic-plugins/dist/
 
 # Copy script to gather dynamic plugins; copy embedded dynamic plugins to root folder; fix permissions
-COPY docker/install-dynamic-plugins.py ./
+COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
+  chmod -R a+rx ./install-dynamic-plugins.sh; \
   rm -fr dynamic-plugins-root && cp -R dynamic-plugins/dist/ dynamic-plugins-root
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.

--- a/docker/brew.Dockerfile
+++ b/docker/brew.Dockerfile
@@ -202,8 +202,9 @@ COPY --from=build --chown=1001:1001 $REMOTE_SOURCES_DIR/ ./
 COPY --from=build $REMOTE_SOURCES_DIR/dynamic-plugins/dist/ ./dynamic-plugins/dist/
 
 # Copy script to gather dynamic plugins; copy embedded dynamic plugins to root folder; fix permissions
-COPY docker/install-dynamic-plugins.py ./
+COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
+  chmod -R a+rx ./install-dynamic-plugins.sh; \
   rm -fr dynamic-plugins-root && cp -R dynamic-plugins/dist/ dynamic-plugins-root
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.

--- a/docker/install-dynamic-plugins.sh
+++ b/docker/install-dynamic-plugins.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2023 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+python install-dynamic-plugins.py $1


### PR DESCRIPTION
## Description

This PR adds an `installDynamicPlugins.sh` shell script that runs the `install-dynamic-plugins.py` python script.

This will avoid surfacing the use of `python` in the helm chart (when defining the `initContainer` command.
The goal here is to make it easy and transparent (no required change in the Helm Chart), if we want to implement dynamic plugin installation in another language - as a node CLI for example) 

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
