### PR TITLE
Change import of HostDiscovery

### DIFF
--- a/.changeset/fresh-parrots-develop.md
+++ b/.changeset/fresh-parrots-develop.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Change the import of HostDiscovery from @backstage/backend-common to @backstage/backend-app-api

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,11 +1,11 @@
 import {
   createConfigSecretEnumerator,
   loadBackendConfig,
+  HostDiscovery,
 } from '@backstage/backend-app-api';
 import {
   CacheManager,
   DatabaseManager,
-  HostDiscovery,
   ServerTokenManager,
   ServiceBuilder,
   UrlReaders,


### PR DESCRIPTION
## Description

Updates the import of HostDiscovery from @backstage/backend-common to @backstage/backend-app-api. 

There seems to have been a recent update to `@backstage/backend-app-api` and `@backstage/backend-common` that mentions [HostDiscovery](https://github.com/backstage/backstage/blob/master/packages/backend-common/CHANGELOG.md#patch-changes-3) is now deprecated in backend-common and to now import it from backend-app-api

## Which issue(s) does this PR fix

- Fixes #771

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
