### PR TITLE
feat(dynamic-plugins): add techdocs dynamic wrapper

### DIFF
--- a/.changeset/slow-adults-admire.md
+++ b/.changeset/slow-adults-admire.md
@@ -1,0 +1,6 @@
+---
+'backstage-plugin-techdocs': minor
+'app': minor
+---
+
+Change TechDocs frontend to a dynamic plugin and allow search page extensions through mountpoints

--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -339,3 +339,41 @@ dynamicPlugins:
             if:
               allOf:
                 - isSecurityInsightsAvailable
+    backstage.plugin-techdocs:
+      routeBindings:
+        targets:
+          - importName: techdocsPlugin
+        bindings:
+          - bindTarget: catalogPlugin.externalRoutes
+            bindMap:
+              viewTechDoc: techdocsPlugin.routes.docRoot
+          - bindTarget: scaffolderPlugin.externalRoutes
+            bindMap:
+              viewTechDoc: techdocsPlugin.routes.docRoot
+      dynamicRoutes:
+        - path: /docs
+          importName: TechDocsIndexPage
+          menuItem:
+            icon: docs
+            text: Docs
+        - path: /docs/:namespace/:kind/:name/*
+          importName: TechDocsReaderPage
+      mountPoints:
+        - mountPoint: entity.page.docs/cards
+          importName: EntityTechdocsContent
+          config:
+            layout:
+              gridColumn: "1 / -1"
+            if:
+              allOf:
+                - isTechDocsAvailable
+        - mountPoint: search.page.results
+          importName: TechDocsSearchResultListItem
+        - mountPoint: search.page.filters
+          importName: TechdocsSearchFilter
+        - mountPoint: search.page.types
+          importName: techdocsSearchType
+          config:
+            props:
+              name: Documentation
+              icon: docs

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -426,6 +426,72 @@ plugins:
                     - isKind: resource
                     - isType: kubernetes-cluster
 
+  # Techdocs
+  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
+    disabled: true
+    pluginConfig:
+      # Reference documentation http://backstage.io/docs/features/techdocs/configuration
+      # Note: After experimenting with basic setup, use CI/CD to generate docs
+      # and an external cloud storage when deploying TechDocs for production use-case.
+      # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+      techdocs:
+        builder: ${TECHDOCS_BUILDER_TYPE}
+        generator:
+          runIn: ${TECHDOCS_GENERATOR_TYPE}
+        publisher:
+          type: ${TECHDOCS_PUBLISHER_TYPE}
+          awsS3:
+            bucketName: ${BUCKET_NAME}
+            region: ${BUCKET_REGION_VAULT}
+            endpoint: ${BUCKET_URL}
+            s3ForcePathStyle: true
+            credentials:
+              accessKeyId: ${AWS_ACCESS_KEY_ID}
+              secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
+    disabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage.plugin-techdocs:
+            routeBindings:
+              targets:
+                - importName: techdocsPlugin
+              bindings:
+                - bindTarget: catalogPlugin.externalRoutes
+                  bindMap:
+                    viewTechDoc: techdocsPlugin.routes.docRoot
+                - bindTarget: scaffolderPlugin.externalRoutes
+                  bindMap:
+                    viewTechDoc: techdocsPlugin.routes.docRoot
+            dynamicRoutes:
+              - path: /docs
+                importName: TechDocsIndexPage
+                menuItem:
+                  icon: docs
+                  text: Docs
+              - path: /docs/:namespace/:kind/:name/*
+                importName: TechDocsReaderPage
+            mountPoints:
+              - mountPoint: entity.page.docs/cards
+                importName: EntityTechdocsContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isTechDocsAvailable
+              - mountPoint: search.page.results
+                importName: TechDocsSearchResultListItem
+              - mountPoint: search.page.filters
+                importName: TechdocsSearchFilter
+              - mountPoint: search.page.types
+                importName: techdocsSearchType
+                config:
+                  props:
+                    name: Documentation
+                    icon: docs
+
   # Standalone plugins
   - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic
 
@@ -451,28 +517,6 @@ plugins:
               realm: "${KEYCLOAK_REALM}"
               clientId: "${KEYCLOAK_CLIENT_ID}"
               clientSecret: "${KEYCLOAK_CLIENT_SECRET}"
-
-  - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
-    disabled: true
-    pluginConfig:
-      # Reference documentation http://backstage.io/docs/features/techdocs/configuration
-      # Note: After experimenting with basic setup, use CI/CD to generate docs
-      # and an external cloud storage when deploying TechDocs for production use-case.
-      # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
-      techdocs:
-        builder: ${TECHDOCS_BUILDER_TYPE}
-        generator:
-          runIn: ${TECHDOCS_GENERATOR_TYPE}
-        publisher:
-          type: ${TECHDOCS_PUBLISHER_TYPE}
-          awsS3:
-            bucketName: ${BUCKET_NAME}
-            region: ${BUCKET_REGION_VAULT}
-            endpoint: ${BUCKET_URL}
-            s3ForcePathStyle: true
-            credentials:
-              accessKeyId: ${AWS_ACCESS_KEY_ID}
-              secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 
   - package: ./dynamic-plugins/dist/backstage-plugin-dynatrace
     disabled: true

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -31,7 +31,7 @@
     "@backstage/plugin-catalog-backend-module-github": "0.4.4"
   },
   "devDependencies": {
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-pagerduty/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-pagerduty/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/.eslintrc.js
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "backstage-plugin-azure-devops",
-  "version": "0.3.7",
+  "name": "backstage-plugin-techdocs",
+  "version": "1.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -20,7 +20,15 @@
     "export-dynamic": "janus-cli package export-dynamic-plugin"
   },
   "dependencies": {
-    "@backstage/plugin-azure-devops": "0.3.7"
+    "@backstage/core-plugin-api": "1.7.0",
+    "@backstage/plugin-catalog-react": "1.8.5",
+    "@backstage/plugin-search-react": "1.7.1",
+    "@backstage/plugin-techdocs": "1.8.0",
+    "@backstage/plugin-techdocs-module-addons-contrib": "1.1.1",
+    "@backstage/plugin-techdocs-react": "1.1.12"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
@@ -31,7 +39,7 @@
     "dist-scalprum"
   ],
   "scalprum": {
-    "name": "backstage.plugin-azure-devops",
+    "name": "backstage.plugin-techdocs",
     "exposedModules": {
       "PluginRoot": "./src/index.ts"
     }

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/index.ts
@@ -1,0 +1,7 @@
+export * from '@backstage/plugin-techdocs';
+export {
+  TechDocsReaderPage,
+  EntityTechdocsContent,
+  TechdocsSearchFilter,
+  techdocsSearchType,
+} from './wrapped';

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/wrapped.tsx
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/wrapped.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
+import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
+import {
+  TechDocsReaderPage as TechDocsReaderPageBase,
+  EntityTechdocsContent as EntityTechdocsContentBase,
+} from '@backstage/plugin-techdocs';
+
+import { SearchFilter, useSearch } from '@backstage/plugin-search-react';
+
+import {
+  CATALOG_FILTER_EXISTS,
+  catalogApiRef,
+} from '@backstage/plugin-catalog-react';
+
+import { useApi } from '@backstage/core-plugin-api';
+
+export const TechDocsReaderPage = {
+  element: TechDocsReaderPageBase,
+  staticJSXContent: (
+    <TechDocsAddons>
+      <ReportIssue />
+    </TechDocsAddons>
+  ),
+};
+
+export const EntityTechdocsContent = {
+  element: EntityTechdocsContentBase,
+  staticJSXContent: (
+    <TechDocsAddons>
+      <ReportIssue />
+    </TechDocsAddons>
+  ),
+};
+
+export const TechdocsSearchFilter = () => {
+  const { types } = useSearch();
+  const catalogApi = useApi(catalogApiRef);
+
+  if (!types.includes('techdocs')) {
+    return null;
+  }
+
+  return (
+    <SearchFilter.Select
+      label="Entity"
+      name="name"
+      values={async () => {
+        // Return a list of entities which are documented.
+        const { items } = await catalogApi.getEntities({
+          fields: ['metadata.name'],
+          filter: {
+            'metadata.annotations.backstage.io/techdocs-ref':
+              CATALOG_FILTER_EXISTS,
+          },
+        });
+        return items.map(entity => entity.metadata.name).sort();
+      }}
+    />
+  );
+};
+
+export const techdocsSearchType = (name: string, icon: React.ReactNode) => ({
+  name,
+  icon,
+  value: 'techdocs',
+});

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "0.23.1",
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   "files": [
     "dist",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,9 +35,6 @@
     "@backstage/plugin-search": "1.4.1",
     "@backstage/plugin-search-react": "1.7.1",
     "@backstage/plugin-tech-radar": "0.6.9",
-    "@backstage/plugin-techdocs": "1.8.0",
-    "@backstage/plugin-techdocs-module-addons-contrib": "1.1.1",
-    "@backstage/plugin-techdocs-react": "1.1.12",
     "@backstage/plugin-user-settings": "0.7.11",
     "@backstage/theme": "0.4.3",
     "@emotion/react": "11.11.1",
@@ -59,7 +56,7 @@
   },
   "devDependencies": {
     "@backstage/test-utils": "1.4.4",
-    "@janus-idp/cli": "1.4.0",
+    "@janus-idp/cli": "1.4.2",
     "@scalprum/react-test-utils": "0.0.5",
     "@testing-library/dom": "8.20.1",
     "@testing-library/jest-dom": "5.17.0",

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -20,9 +20,6 @@ describe('App', () => {
           data: {
             app: { title: 'Test' },
             backend: { baseUrl: 'http://localhost:7007' },
-            techdocs: {
-              storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
-            },
             auth: { environment: 'development' },
           },
           context: 'test',

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -10,12 +10,6 @@ import { RequirePermission } from '@backstage/plugin-permission-react';
 import { ScaffolderPage } from '@backstage/plugin-scaffolder';
 import { SearchPage as BackstageSearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
-import {
-  TechDocsIndexPage,
-  TechDocsReaderPage,
-} from '@backstage/plugin-techdocs';
-import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
-import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
 import React, { useContext } from 'react';
 import { Route } from 'react-router-dom';
@@ -48,15 +42,6 @@ const AppBase = () => {
             >
               {entityPage}
             </Route>
-            <Route path="/docs" element={<TechDocsIndexPage />} />
-            <Route
-              path="/docs/:namespace/:kind/:name/*"
-              element={<TechDocsReaderPage />}
-            >
-              <TechDocsAddons>
-                <ReportIssue />
-              </TechDocsAddons>
-            </Route>
             <Route
               path="/create"
               element={
@@ -84,13 +69,17 @@ const AppBase = () => {
             <Route path="/settings" element={<UserSettingsPage />} />
             <Route path="/catalog-graph" element={<CatalogGraphPage />} />
             <Route path="/learning-paths" element={<LearningPaths />} />
-            {dynamicRoutes.map(({ Component, path, ...props }) => (
-              <Route
-                key={path}
-                path={path}
-                element={<Component {...props} />}
-              />
-            ))}
+            {dynamicRoutes.map(
+              ({ Component, staticJSXContent, path, ...props }) => (
+                <Route
+                  key={path}
+                  path={path}
+                  element={<Component {...props} />}
+                >
+                  {staticJSXContent}
+                </Route>
+              ),
+            )}
           </FlatRoutes>
         </Root>
       </AppRouter>

--- a/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
@@ -142,6 +142,7 @@ const DynamicRoot = ({
         mountPoint: string;
         Component: React.ComponentType<{}>;
         config?: ScalprumMountPointConfig;
+        staticJSXContent?: React.ReactNode;
       }[]
     >((acc, { module, importName, mountPoint, scope, config }) => {
       const Component = remotePlugins[scope]?.[module]?.[importName];
@@ -170,7 +171,14 @@ const DynamicRoot = ({
 
         acc.push({
           mountPoint,
-          Component: Component as React.ComponentType<{}>,
+          Component:
+            typeof Component === 'object' && 'element' in Component
+              ? (Component.element as React.ComponentType<{}>)
+              : (Component as React.ComponentType<{}>),
+          staticJSXContent:
+            typeof Component === 'object' && 'staticJSXContent' in Component
+              ? (Component.staticJSXContent as React.ReactNode)
+              : null,
           config: {
             ...config,
             if: ifCondition,
@@ -193,6 +201,7 @@ const DynamicRoot = ({
       }
       acc[entry.mountPoint].push({
         Component: entry.Component,
+        staticJSXContent: entry.staticJSXContent,
         config: entry.config,
       });
       return acc;
@@ -203,6 +212,7 @@ const DynamicRoot = ({
     const dynamicRoutesComponents = dynamicRoutes.reduce<
       (DynamicRoute & {
         Component: React.ComponentType<{}>;
+        staticJSXContent?: React.ReactNode;
       })[]
     >((acc, route) => {
       const Component =
@@ -210,7 +220,14 @@ const DynamicRoot = ({
       if (Component) {
         acc.push({
           ...route,
-          Component: Component as React.ComponentType<{}>,
+          Component:
+            typeof Component === 'object' && 'element' in Component
+              ? (Component.element as React.ComponentType<{}>)
+              : (Component as React.ComponentType<{}>),
+          staticJSXContent:
+            typeof Component === 'object' && 'staticJSXContent' in Component
+              ? (Component.staticJSXContent as React.ReactNode)
+              : null,
         });
       } else {
         // eslint-disable-next-line no-console

--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -24,6 +24,7 @@ export type DynamicRootContextValue = DynamicModuleEntry & {
   path: string;
   menuItem?: MenuItem;
   Component: React.ComponentType<any>;
+  staticJSXContent?: React.ReactNode;
 };
 
 type ScalprumMountPointConfigBase = {
@@ -51,6 +52,7 @@ export type ScalprumMountPointConfigRaw = ScalprumMountPointConfigBase & {
 export type ScalprumMountPoint = {
   Component: React.ComponentType<{}>;
   config?: ScalprumMountPointConfig;
+  staticJSXContent?: React.ReactNode;
 };
 
 export type RemotePlugins = {
@@ -59,7 +61,11 @@ export type RemotePlugins = {
       [importName: string]:
         | React.ComponentType<{}>
         | ((...args: any[]) => any)
-        | BackstagePlugin<{}>;
+        | BackstagePlugin<{}>
+        | {
+            element: React.ComponentType<{}>;
+            staticJSXContent: React.ReactNode;
+          };
     };
   };
 };

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -16,7 +16,6 @@ import CreateComponentIcon from '@mui/icons-material/AddCircleOutline';
 import AppsIcon from '@mui/icons-material/Apps';
 import ExtensionIcon from '@mui/icons-material/Extension';
 import HomeIcon from '@mui/icons-material/Home';
-import LibraryBooks from '@mui/icons-material/LibraryBooks';
 import MuiMenuIcon from '@mui/icons-material/Menu';
 import MapIcon from '@mui/icons-material/MyLocation';
 import SchoolIcon from '@mui/icons-material/School';
@@ -51,7 +50,7 @@ const SideBarItemWrapper = (props: SidebarItemProps) => {
   );
 };
 
-const MenuIcon = ({ icon }: { icon: string }) => {
+export const MenuIcon = ({ icon }: { icon: string }) => {
   const app = useApp();
 
   const Icon = app.getSystemIcon(icon) || (() => null);
@@ -80,11 +79,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
             icon={ExtensionIcon as any}
             to="api-docs"
             text="APIs"
-          />
-          <SideBarItemWrapper
-            icon={LibraryBooks as any}
-            to="docs"
-            text="Docs"
           />
           <SideBarItemWrapper
             icon={SchoolIcon as any}

--- a/packages/app/src/components/catalog/EntityPage/index.tsx
+++ b/packages/app/src/components/catalog/EntityPage/index.tsx
@@ -33,12 +33,6 @@ import {
   EntityCatalogGraphCard,
 } from '@backstage/plugin-catalog-graph';
 import {
-  EntityTechdocsContent,
-  isTechDocsAvailable,
-} from '@backstage/plugin-techdocs';
-import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
-import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
-import {
   EntityGroupProfileCard,
   EntityMembersListCard,
   EntityOwnershipCard,
@@ -478,20 +472,6 @@ export const entityPage = (
       path: '/docs',
       title: 'Docs',
       mountPoint: 'entity.page.docs',
-      if: isTechDocsAvailable,
-      children: (
-        <EntitySwitch>
-          <EntitySwitch.Case if={isTechDocsAvailable}>
-            <Grid item sx={{ gridColumn: '1 / -1' }}>
-              <EntityTechdocsContent>
-                <TechDocsAddons>
-                  <ReportIssue />
-                </TechDocsAddons>
-              </EntityTechdocsContent>
-            </Grid>
-          </EntitySwitch.Case>
-        </EntitySwitch>
-      ),
     })}
 
     {tab({

--- a/packages/app/src/components/catalog/tab/tab.tsx
+++ b/packages/app/src/components/catalog/tab/tab.tsx
@@ -36,17 +36,17 @@ const tab = ({
       ),
       <Grid container>
         {children}
-        {getMountPointData<React.ComponentType>(`${mountPoint}/cards`).map(
-          ({ Component, config }) => (
-            <EntitySwitch key={`${Component.displayName}`}>
-              <EntitySwitch.Case if={config.if}>
-                <Box sx={config.layout}>
-                  <Component {...config.props} />
-                </Box>
-              </EntitySwitch.Case>
-            </EntitySwitch>
-          ),
-        )}
+        {getMountPointData<React.ComponentType, React.ReactNode>(
+          `${mountPoint}/cards`,
+        ).map(({ Component, config, staticJSXContent }) => (
+          <EntitySwitch key={`${Component.displayName}`}>
+            <EntitySwitch.Case if={config.if}>
+              <Box sx={config.layout}>
+                <Component {...config.props}>{staticJSXContent}</Component>
+              </Box>
+            </EntitySwitch.Case>
+          </EntitySwitch>
+        ))}
       </Grid>,
     )}
   </EntityLayout.Route>

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -3,29 +3,18 @@ import Paper from '@mui/material/Paper';
 import React from 'react';
 
 import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
-import {
-  CATALOG_FILTER_EXISTS,
-  catalogApiRef,
-} from '@backstage/plugin-catalog-react';
-import { TechDocsSearchResultListItem } from '@backstage/plugin-techdocs';
 
-import {
-  CatalogIcon,
-  Content,
-  DocsIcon,
-  Header,
-  Page,
-} from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { CatalogIcon, Content, Header, Page } from '@backstage/core-components';
 import { SearchType } from '@backstage/plugin-search';
 import {
   SearchBar,
   SearchFilter,
   SearchPagination,
   SearchResult,
-  useSearch,
 } from '@backstage/plugin-search-react';
 import { makeStyles } from 'tss-react/mui';
+import getMountPointData from '../../utils/dynamicUI/getMountPointData';
+import { MenuIcon } from '../Root/Root';
 
 const useStyles = makeStyles()(theme => ({
   searchBar: {
@@ -35,12 +24,10 @@ const useStyles = makeStyles()(theme => ({
   },
   filters: {
     padding: theme.spacing(2),
+    gap: theme.spacing(2.5),
     marginTop: theme.spacing(2),
-  },
-  filter: {
-    '& + &': {
-      marginTop: theme.spacing(2.5),
-    },
+    display: 'flex',
+    flexDirection: 'column',
   },
   notchedOutline: {
     borderStyle: 'none!important',
@@ -49,8 +36,6 @@ const useStyles = makeStyles()(theme => ({
 
 export const SearchPage = () => {
   const { classes } = useStyles();
-  const { types } = useSearch();
-  const catalogApi = useApi(catalogApiRef);
 
   return (
     <Page themeId="home">
@@ -78,54 +63,62 @@ export const SearchPage = () => {
                   name: 'Software Catalog',
                   icon: <CatalogIcon />,
                 },
-                {
-                  value: 'techdocs',
-                  name: 'Documentation',
-                  icon: <DocsIcon />,
-                },
+                ...getMountPointData<
+                  (
+                    name: string,
+                    icon: React.ReactElement,
+                  ) => {
+                    name: string;
+                    icon: React.ReactElement;
+                    value: string;
+                  }
+                >('search.page.types').map(
+                  ({ Component: getSearchType, config: { props } }) =>
+                    getSearchType(
+                      props?.name || '',
+                      <MenuIcon icon={props?.icon || ''} />,
+                    ),
+                ),
               ]}
             />
             <Paper className={classes.filters}>
-              {types.includes('techdocs') && (
-                <SearchFilter.Select
-                  className={classes.filter}
-                  label="Entity"
-                  name="name"
-                  values={async () => {
-                    // Return a list of entities which are documented.
-                    const { items } = await catalogApi.getEntities({
-                      fields: ['metadata.name'],
-                      filter: {
-                        'metadata.annotations.backstage.io/techdocs-ref':
-                          CATALOG_FILTER_EXISTS,
-                      },
-                    });
-
-                    const names = items.map(entity => entity.metadata.name);
-                    names.sort();
-                    return names;
-                  }}
-                />
-              )}
               <SearchFilter.Select
-                className={classes.filter}
                 label="Kind"
                 name="kind"
                 values={['Component', 'Template']}
               />
               <SearchFilter.Checkbox
-                className={classes.filter}
                 label="Lifecycle"
                 name="lifecycle"
                 values={['experimental', 'production']}
               />
+              {...getMountPointData<React.ComponentType>(
+                'search.page.filters',
+              ).map(({ Component, config }, idx) => {
+                return (
+                  <Component key={`search_filter_${idx}`} {...config.props} />
+                );
+              })}
             </Paper>
           </Grid>
           <Grid item xs={9}>
             <SearchPagination />
             <SearchResult>
               <CatalogSearchResultListItem icon={<CatalogIcon />} />
-              <TechDocsSearchResultListItem icon={<DocsIcon />} />
+              {getMountPointData<React.ComponentType>(
+                'search.page.results',
+              ).map(({ Component, config }, idx) => {
+                const ComponentWithIcon = Component as React.FunctionComponent<{
+                  icon: React.ReactElement;
+                }>;
+                return (
+                  <ComponentWithIcon
+                    {...config.props}
+                    key={`search_results_${idx}`}
+                    icon={<MenuIcon icon={config.props?.icon || ''} />}
+                  />
+                );
+              })}
             </SearchResult>
           </Grid>
         </Grid>

--- a/packages/app/src/utils/dynamicUI/bindAppRoutes.ts
+++ b/packages/app/src/utils/dynamicUI/bindAppRoutes.ts
@@ -4,7 +4,6 @@ import { catalogPlugin } from '@backstage/plugin-catalog';
 import { catalogImportPlugin } from '@backstage/plugin-catalog-import';
 import { orgPlugin } from '@backstage/plugin-org';
 import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
-import { techdocsPlugin } from '@backstage/plugin-techdocs';
 import get from 'lodash/get';
 import { RouteBinding } from '../../components/DynamicRoot/DynamicRootContext';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
@@ -17,7 +16,6 @@ const bindAppRoutes = (
   // Static bindings
   bind(catalogPlugin.externalRoutes, {
     createComponent: scaffolderPlugin.routes.root,
-    viewTechDoc: techdocsPlugin.routes.docRoot,
     createFromTemplate: scaffolderPlugin.routes.selectedTemplate,
   });
   bind(apiDocsPlugin.externalRoutes, {
@@ -25,7 +23,6 @@ const bindAppRoutes = (
   });
   bind(scaffolderPlugin.externalRoutes, {
     registerComponent: catalogImportPlugin.routes.importPage,
-    viewTechDoc: techdocsPlugin.routes.docRoot,
   });
   bind(orgPlugin.externalRoutes, {
     catalogIndex: catalogPlugin.routes.catalogIndex,
@@ -35,9 +32,9 @@ const bindAppRoutes = (
     ...routeBindingTargets,
     catalogPlugin,
     catalogImportPlugin,
-    techdocsPlugin,
     scaffolderPlugin,
   };
+
   // binds from remote
   routeBindings.forEach(({ bindTarget, bindMap }) => {
     const externalRoutes = get(availableBindPlugins, bindTarget);

--- a/packages/app/src/utils/dynamicUI/getMountPointData.ts
+++ b/packages/app/src/utils/dynamicUI/getMountPointData.ts
@@ -1,9 +1,9 @@
 import { getScalprum } from '@scalprum/core';
 import { ScalprumMountPointConfig } from '../../components/DynamicRoot/DynamicRootContext';
 
-function getMountPointData<T = any>(
+function getMountPointData<T = any, T2 = any>(
   mountPoint: string,
-): { config: ScalprumMountPointConfig; Component: T }[] {
+): { config: ScalprumMountPointConfig; Component: T; staticJSXContent: T2 }[] {
   return getScalprum().api.mountPoints?.[mountPoint] ?? [];
 }
 

--- a/packages/app/src/utils/test/TestRoot.tsx
+++ b/packages/app/src/utils/test/TestRoot.tsx
@@ -10,7 +10,6 @@ import { orgPlugin } from '@backstage/plugin-org';
 import { apis } from '../../apis';
 import DynamicRootContext from '../../components/DynamicRoot/DynamicRootContext';
 import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
-import { techdocsPlugin } from '@backstage/plugin-techdocs';
 
 const TestRoot = ({ children }: PropsWithChildren<{}>) => {
   const { current } = useRef<BackstageApp>(
@@ -20,7 +19,6 @@ const TestRoot = ({ children }: PropsWithChildren<{}>) => {
         // Static bindings
         bind(catalogPlugin.externalRoutes, {
           createComponent: scaffolderPlugin.routes.root,
-          viewTechDoc: techdocsPlugin.routes.docRoot,
           createFromTemplate: scaffolderPlugin.routes.selectedTemplate,
         });
         bind(apiDocsPlugin.externalRoutes, {
@@ -28,7 +26,6 @@ const TestRoot = ({ children }: PropsWithChildren<{}>) => {
         });
         bind(scaffolderPlugin.externalRoutes, {
           registerComponent: catalogImportPlugin.routes.importPage,
-          viewTechDoc: techdocsPlugin.routes.docRoot,
         });
         bind(orgPlugin.externalRoutes, {
           catalogIndex: catalogPlugin.routes.catalogIndex,

--- a/showcase-docs/dynamic-plugins.md
+++ b/showcase-docs/dynamic-plugins.md
@@ -49,7 +49,7 @@ These recommended changes to the `package.json` are summarized below:
   }
   ...
   "devDependencies": {
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   ...
   "files": [
@@ -185,7 +185,7 @@ These recommended changes to the `package.json` are summarized below:
   },
   ...
   "devDependencies": {
-    "@janus-idp/cli": "1.4.0"
+    "@janus-idp/cli": "1.4.2"
   },
   ...
   "files": [
@@ -223,6 +223,25 @@ However if you want to customize Scalprum's behavior, you can do so by including
   },
   ...
 ```
+
+Dynamic plugins may also need to adopt to specific Backstage needs like static JSX children for mountpoints and dynamic routes. These changes are strictly optional and exported symbols are incompatible with static plugins:
+
+1. To include static JSX as element children with your dynamically imported component, please define an additional export as follows and use that as your dynamic plugin `importName`:
+
+   ```tsx
+   // Used by a static plugin
+   export const EntityTechdocsContent = () => {...}
+
+   // Used by a dynamic plugin
+   export const DynamicEntityTechdocsContent = {
+     element: EntityTechdocsContent,
+     staticJSXContent: (
+       <TechDocsAddons>
+         <ReportIssue />
+       </TechDocsAddons>
+     ),
+   };
+   ```
 
 #### Exporting the plugin as a dynamic plugin package
 
@@ -332,10 +351,6 @@ In order to add dynamic plugin support to a third-party plugin, without touching
 The showcase docker image comes pre-loaded with a selection of dynamic plugins, with most being initially deactivated due to the need for mandatory configuration. The complete list of these plugins is detailed in the [`dynamic-plugins.default.yaml`](https://github.com/janus-idp/backstage-showcase/blob/main/dynamic-plugins.default.yaml) file.
 
 Upon application startup, for each plugin that is disabled by default, the `install-dynamic-plugins` init container within the `backstage` Pod's log will display a line similar to the following:
-
-```
-======= Skipping disabled dynamic plugin ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
-```
 
 To activate this plugin, simply add a package with the same name and adjust the `disabled` field in the helm chart values as shown below:
 
@@ -604,6 +619,9 @@ The following mount points are available:
 | `entity.page.docs`           | Catalog entity "Documentation" tab  | YES for entity that satisfies `isTechDocsAvailable`            |
 | `entity.page.definition`     | Catalog entity "Definitions" tab    | YES for entity of `kind: Api`                                  |
 | `entity.page.diagram`        | Catalog entity "Diagram" tab        | YES for entity of `kind: System`                               |
+| `search.page.types`          | Search result type                  | YES, default catalog search type is available                  |
+| `search.page.filters`        | Search filters                      | YES, default catalog kind and lifecycle filters are visible    |
+| `search.page.results`        | Search results content              | YES, default catalog search is present                         |
 
 Note: Mount points within Catalog aka `entity.page.*` are rendered as tabs. They become visible only if at least one plugin contributes to them or they can render static content (see column 3 in previous table).
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5441,10 +5441,10 @@
   dependencies:
     "@backstage/plugin-permission-common" "^0.7.9"
 
-"@janus-idp/cli@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.4.0.tgz#b28801b68abce0e4c12249de3dd5d0267bd704bc"
-  integrity sha512-xa+IVdvw3zquhlRylnMEPse3zfSyvk9QzGZc42dcALvHmOrpiuRYFhYkT+tQFbBlMU+oASzvLpvu1KR8eFo/1w==
+"@janus-idp/cli@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@janus-idp/cli/-/cli-1.4.2.tgz#6c8db3c29296d16371564237d31b019a64dce546"
+  integrity sha512-tvB+956Wyr+zKUKYLd5h5HA5533jhIRjkxVtV0CTDYYAn0M2/X91Q0k5fEUaVVtLvNDGJPV/s7EqDMgfGKTk+Q==
   dependencies:
     "@backstage/cli-common" "^0.1.13"
     "@backstage/cli-node" "^0.1.5"


### PR DESCRIPTION
## Description

Utilizes https://github.com/janus-idp/backstage-showcase/pull/774

Example implementation of the `routeBindings` via switching the TechDocs plugin to dynamic.

In addition to that, TechDocs requires us to pass static JSX into children to enable addons. This PR implements an additional API allowing users to define exports as:

```tsx
React.ComponentType<{}> |
{
  element: React.ComponentType<{}>,
  staticJSXContent: React.ReactNode
}
```

This PR also brings 3 new dynamic frontend mountpoints:

- `search.page.types`
- `search.page.filters`
- `search.page.results`


## Which issue(s) does this PR fix

Depends on: https://github.com/janus-idp/backstage-showcase/pull/774

Part of: https://github.com/janus-idp/backstage-showcase/issues/741

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
