### PR TITLE
fix: `yarn.lock` files missed by cachito replacement

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,11 @@ RUN rm app-config.yaml && mv app-config.example.yaml app-config.yaml
 RUN $YARN build --filter=backend
 
 # Build dynamic plugins
-RUN $YARN export-dynamic
+# The special case for imports here is for consistency with downstream
+# though for upstream it wouldn't be necessary
+RUN $YARN --cwd ./dynamic-plugins/imports export-dynamic --no-install
+RUN $YARN --cwd ./dynamic-plugins/imports install-dynamic
+RUN $YARN export-dynamic -- --filter=./dynamic-plugins/wrappers/*
 RUN $YARN copy-dynamic-plugins dist
 
 # Stage 4 - Build the actual backend image and install production dependencies

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "export-dynamic": "node ./import-plugins.js",
+    "install-dynamic": "node ./import-plugins.js --install-only",
     "lint": "backstage-cli package lint"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of the change

Some `yarn.lock` files (the one in the imported backend dynamic plugins) were missed by the cachito replacement that occurs during the downstream docker build.

This PR fixes it.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [ ] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [ ] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
