### PR TITLE
disable plugin roadiehq-scaffolder-backend-module-utils-dynamic

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -494,6 +494,7 @@ plugins:
 
   # Standalone plugins
   - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic
+    disabled: true
 
   - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-aap-backend-dynamic
     disabled: true


### PR DESCRIPTION
## Description

Disable plugin roadiehq-scaffolder-backend-module-utils-dynamic by default

## Which issue(s) does this PR fix

- Fixes #801 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
