### PR TITLE
fix: update keycloak plugin to fix not a constructor error

### DIFF
--- a/.changeset/shy-berries-confess.md
+++ b/.changeset/shy-berries-confess.md
@@ -1,0 +1,5 @@
+---
+'dynamic-plugins-imports': patch
+---
+
+Update keycloak plugin to address https://github.com/janus-idp/backstage-plugins/issues/949

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -19,7 +19,7 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.4.4",
     "@janus-idp/backstage-plugin-acr": "1.2.4",
     "@janus-idp/backstage-plugin-jfrog-artifactory": "1.2.4",
-    "@janus-idp/backstage-plugin-keycloak-backend": "1.7.4",
+    "@janus-idp/backstage-plugin-keycloak-backend": "1.7.6",
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.4.4",
     "@janus-idp/backstage-plugin-ocm": "3.5.0",
     "@janus-idp/backstage-plugin-ocm-backend": "3.4.5",


### PR DESCRIPTION
## Description

Update Keycloak to consume https://github.com/janus-idp/backstage-plugins/pull/968 fix  for https://github.com/janus-idp/backstage-plugins/issues/949

~Waits for `1.7.6` to be published~

## Which issue(s) does this PR fix

N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
