### PR TITLE
fix: missing .npm directory in Brew build

### DIFF
--- a/docker/brew.Dockerfile
+++ b/docker/brew.Dockerfile
@@ -162,6 +162,9 @@ RUN tar xzf $TARBALL_PATH/skeleton.tar.gz; tar xzf $TARBALL_PATH/bundle.tar.gz; 
 # COPY $EXTERNAL_SOURCE_NESTED/app-config*.yaml ./
 # COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 
+# Downstream only - fix for https://issues.redhat.com/browse/RHIDP-728
+WORKDIR /opt/app-root/src/
+
 # Install production dependencies
 # hadolint ignore=DL3059
 RUN $YARN install --frozen-lockfile --production --network-timeout 600000

--- a/docker/brew.Dockerfile
+++ b/docker/brew.Dockerfile
@@ -215,7 +215,6 @@ RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
 RUN mkdir /opt/app-root/src/.npm
 RUN chown -R 1001:1001 /opt/app-root/src/.npm
 
-
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./

--- a/docker/brew.Dockerfile
+++ b/docker/brew.Dockerfile
@@ -162,9 +162,6 @@ RUN tar xzf $TARBALL_PATH/skeleton.tar.gz; tar xzf $TARBALL_PATH/bundle.tar.gz; 
 # COPY $EXTERNAL_SOURCE_NESTED/app-config*.yaml ./
 # COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 
-# Downstream only - fix for https://issues.redhat.com/browse/RHIDP-728
-WORKDIR /opt/app-root/src/
-
 # Install production dependencies
 # hadolint ignore=DL3059
 RUN $YARN install --frozen-lockfile --production --network-timeout 600000
@@ -213,6 +210,11 @@ COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
   chmod -R a+rx ./install-dynamic-plugins.sh; \
   rm -fr dynamic-plugins-root && cp -R dynamic-plugins/dist/ dynamic-plugins-root
+
+# Downstream only - fix for https://issues.redhat.com/browse/RHIDP-728
+RUN mkdir /opt/app-root/src/.npm
+RUN chown -R 1001:1001 /opt/app-root/src/.npm
+
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.


### PR DESCRIPTION
## Description

This fixes the missing `/opt/app-root/src/.npm` directory in Brew build image that was causing problems on Kubernetes clusters.
More info is at https://issues.redhat.com/browse/RHIDP-728



## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
