### PR TITLE
chore(scalprum-backend): Frontend plugins log line

### DIFF
--- a/.changeset/swift-avocados-jog.md
+++ b/.changeset/swift-avocados-jog.md
@@ -1,0 +1,5 @@
+---
+'@internal/plugin-scalprum-backend': patch
+---
+
+Add logging statements when loading frontend dynamic plugins similar to the logging statements when loading backend dynamic plugins

--- a/plugins/scalprum-backend/src/service/router.ts
+++ b/plugins/scalprum-backend/src/service/router.ts
@@ -76,6 +76,9 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
         name: pkgManifest.name,
         manifestLocation: `${externalBaseUrl}/${pkgManifest.name}/plugin-manifest.json`,
       };
+      logger.info(
+        `Loaded dynamic frontend plugin '${plugin.name}' from '${pkg.location}' `,
+      );
     });
 
   router.get('/plugins', (_, response) => {


### PR DESCRIPTION
## Description

This commit adds a log statement to the scalprum-backend plugin to log each successfully loaded frontend dynamic plugin, using a similar format to what's current used to log backend dynamic plugins.  Here's what it would look like on the console:

![image](https://github.com/janus-idp/backstage-showcase/assets/351660/51e40d8c-e0c5-4d8d-a111-5a0315ef314a)

## Which issue(s) does this PR fix

- Fixes #893

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
