### PR TITLE
feat(notifications): add Notifications plugins to container image

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -118,6 +118,26 @@ plugins:
                   if:
                     allOf:
                       - isSecurityInsightsAvailable
+  # Group: Notifications
+  - package: ./dynamic-plugins/dist/janus-idp-plugin-notifications
+    disabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          janus-idp.backstage-plugin-notifications:
+            appIcons:
+              - name: notificationsIcon
+                module: NotificationsPlugin
+                importName: NotificationsActiveIcon
+            dynamicRoutes:
+              - path: /notifications
+                importName: NotificationsPage
+                module: NotificationsPlugin
+                menuItem:
+                  icon: notificationsIcon
+                  text: Notifications
+  - package: ./dynamic-plugins/dist/janus-idp-plugin-notifications-backend-dynamic
+    disabled: true
 
   # Group: Gitlab
   - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -33,6 +33,8 @@
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.3.0",
     "@janus-idp/backstage-scaffolder-backend-module-regex": "1.3.0",
     "@janus-idp/backstage-scaffolder-backend-module-servicenow": "1.3.0",
-    "@janus-idp/backstage-scaffolder-backend-module-sonarqube": "1.3.0"
+    "@janus-idp/backstage-scaffolder-backend-module-sonarqube": "1.3.0",
+    "@janus-idp/plugin-notifications-backend-dynamic": "1.2.0",
+    "@janus-idp/plugin-notifications": "1.1.6"
   }
 }


### PR DESCRIPTION
## Description

By this change, the Notifications dynamic plugins are included in the `backstage-showcase` container image, disabled by default.

## Requires:
- [x] https://github.com/janus-idp/backstage-plugins/pull/1104

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

![Screenshot from 2024-01-25 12-17-34](https://github.com/janus-idp/backstage-showcase/assets/17194943/4ce843be-0af3-4be2-bf6f-f1b9e180cea9)

---
[Screencast from 2024-01-25 12-16-01.webm](https://github.com/janus-idp/backstage-showcase/assets/17194943/05a4baa8-fa0d-480d-b628-e1ad95aa3fd2)

