### PR TITLE
feat(orchestrator): add Orchestrator plugins into container image

### DIFF
--- a/.changeset/sweet-turkeys-wait.md
+++ b/.changeset/sweet-turkeys-wait.md
@@ -1,0 +1,5 @@
+---
+'dynamic-plugins-imports': major
+---
+
+added new Orchestrator plugins

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -426,6 +426,33 @@ plugins:
                     - isKind: resource
                     - isType: kubernetes-cluster
 
+  # Group: Orchestrator
+  - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-orchestrator
+    disabled: true
+    pluginConfig:      
+      dynamicPlugins:
+        frontend:
+          janus-idp.backstage-plugin-orchestrator:
+            appIcons:
+              - name: orchestratorIcon
+                module: OrchestratorPlugin
+                importName: OrchestratorIcon
+            dynamicRoutes:
+              - path: /orchestrator
+                importName: OrchestratorPage
+                module: OrchestratorPlugin
+                menuItem:
+                  icon: orchestratorIcon
+                  text: Orchestrator                  
+  - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-orchestrator-backend-dynamic
+    disabled: true
+    pluginConfig:
+      orchestrator:
+        dataIndexService:
+          url: http://sonataflow-platform-data-index-service.sonataflow-infra
+        editor:
+          path: https://sandbox.kie.org/swf-chrome-extension/0.32.0
+
   # Techdocs
   - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
     disabled: true

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -25,6 +25,8 @@
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.4.21",
     "@janus-idp/backstage-plugin-ocm": "3.6.1",
     "@janus-idp/backstage-plugin-ocm-backend": "3.4.12",
+    "@janus-idp/backstage-plugin-orchestrator": "1.2.0",
+    "@janus-idp/backstage-plugin-orchestrator-backend-dynamic": "1.1.0",
     "@janus-idp/backstage-plugin-quay": "1.5.2",
     "@janus-idp/backstage-plugin-tekton": "3.5.0",
     "@janus-idp/backstage-plugin-topology": "1.17.6",


### PR DESCRIPTION
## Description

Adds Orchestrator dynamic plugins into `Showcase` container image. The plugins are `disabled` by default.

## Which issue(s) does this PR fix

- Fixes [FLPATH-871](https://issues.redhat.com//browse/FLPATH-871)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
