### PR TITLE
feat(app) an AdminPage for admin plugins

### DIFF
--- a/.changeset/young-numbers-whisper.md
+++ b/.changeset/young-numbers-whisper.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Add an Administration tab and related AdminPage component to act as a holder for dynamic plugins that focus on administrative tasks. Add the dynamic-plugins-info dynamic plugin.

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -498,6 +498,23 @@ plugins:
   - package: ./dynamic-plugins/dist/janus-idp-backstage-scaffolder-backend-module-quay-dynamic
 
   - package: ./dynamic-plugins/dist/janus-idp-backstage-scaffolder-backend-module-regex-dynamic
+    
+  - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-dynamic-plugins-info
+    disabled: true
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          janus-idp.backstage-plugin-dynamic-plugins-info:
+            dynamicRoutes:
+              - path: /admin/plugins
+                importName: DynamicPluginsInfo
+            mountPoints:
+              - mountPoint: admin.page.plugins/cards
+                importName: DynamicPluginsInfo
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                    width: 100vw
 
   - package: ./dynamic-plugins/dist/janus-idp-plugin-rbac
     disabled: true

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -20,6 +20,7 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.4.12",
     "@janus-idp/backstage-plugin-acr": "1.2.21",
     "@janus-idp/backstage-plugin-analytics-provider-segment": "1.2.5",
+    "@janus-idp/backstage-plugin-dynamic-plugins-info": "1.0.0",
     "@janus-idp/backstage-plugin-jfrog-artifactory": "1.2.21",
     "@janus-idp/backstage-plugin-keycloak-backend": "1.7.13",
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.4.21",

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -15,6 +15,7 @@ import { Route } from 'react-router-dom';
 import DynamicRootContext from '../DynamicRoot/DynamicRootContext';
 import { Root } from '../Root';
 import { settingsPage } from '../UserSettings/SettingsPages';
+import { AdminPage } from '../admin/AdminPage';
 import { entityPage } from '../catalog/EntityPage';
 import { HomePage } from '../home/HomePage';
 import { LearningPaths } from '../learningPaths/LearningPathsPage';
@@ -67,6 +68,16 @@ const AppBase = () => {
             </Route>
             <Route path="/catalog-graph" element={<CatalogGraphPage />} />
             <Route path="/learning-paths" element={<LearningPaths />} />
+            <Route path="/admin" element={<AdminPage />} />
+            {dynamicRoutes
+              .filter(({ path }) => path.startsWith('/admin'))
+              .map(({ path }) => (
+                <Route
+                  key={`admin-path-${path}`}
+                  path={path}
+                  element={<AdminPage />}
+                />
+              ))}
             {dynamicRoutes.map(
               ({ Component, staticJSXContent, path, config: { props } }) => (
                 <Route

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -13,6 +13,7 @@ import {
   UserSettingsSignInAvatar,
 } from '@backstage/plugin-user-settings';
 import CreateComponentIcon from '@mui/icons-material/AddCircleOutline';
+import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined';
 import AppsIcon from '@mui/icons-material/Apps';
 import ExtensionIcon from '@mui/icons-material/Extension';
 import HomeIcon from '@mui/icons-material/Home';
@@ -23,7 +24,7 @@ import { makeStyles } from 'tss-react/mui';
 import React, { PropsWithChildren, useContext } from 'react';
 import { SidebarLogo } from './SidebarLogo';
 import DynamicRootContext from '../DynamicRoot/DynamicRootContext';
-import { useApp } from '@backstage/core-plugin-api';
+import { IconComponent, useApp } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles()({
   sidebarItem: {
@@ -57,7 +58,7 @@ export const MenuIcon = ({ icon }: { icon: string }) => {
 };
 
 export const Root = ({ children }: PropsWithChildren<{}>) => {
-  const { dynamicRoutes } = useContext(DynamicRootContext);
+  const { dynamicRoutes, mountPoints } = useContext(DynamicRootContext);
   return (
     <SidebarPage>
       <Sidebar>
@@ -70,22 +71,22 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           {/* Global nav, not org-specific */}
           <SideBarItemWrapper icon={HomeIcon as any} to="/" text="Home" />
           <SideBarItemWrapper
-            icon={AppsIcon as any}
+            icon={AppsIcon as IconComponent}
             to="catalog"
             text="Catalog"
           />
           <SideBarItemWrapper
-            icon={ExtensionIcon as any}
+            icon={ExtensionIcon as IconComponent}
             to="api-docs"
             text="APIs"
           />
           <SideBarItemWrapper
-            icon={SchoolIcon as any}
+            icon={SchoolIcon as IconComponent}
             to="learning-paths"
             text="Learning Paths"
           />
           <SideBarItemWrapper
-            icon={CreateComponentIcon as any}
+            icon={CreateComponentIcon as IconComponent}
             to="create"
             text="Create..."
           />
@@ -108,6 +109,17 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarGroup>
         <SidebarSpace />
         <SidebarDivider />
+        {Object.keys(mountPoints).some(scope =>
+          scope.startsWith('admin.page'),
+        ) ? (
+          <SideBarItemWrapper
+            icon={AdminPanelSettingsOutlinedIcon as IconComponent}
+            to="/admin"
+            text="Administration"
+          />
+        ) : (
+          <></>
+        )}
         <SidebarGroup
           label="Settings"
           icon={<UserSettingsSignInAvatar />}

--- a/packages/app/src/components/admin/AdminPage.test.tsx
+++ b/packages/app/src/components/admin/AdminPage.test.tsx
@@ -1,0 +1,261 @@
+import React, { Fragment } from 'react';
+
+import initializeRemotePlugins from '../../utils/dynamicUI/initializeRemotePlugins';
+import { createPlugin, createRouteRef } from '@backstage/core-plugin-api';
+import { removeScalprum } from '@scalprum/core';
+import * as useAsync from 'react-use/lib/useAsync';
+import { renderWithEffects } from '@backstage/test-utils';
+import AppBase from '../AppBase/AppBase';
+import { act } from 'react-dom/test-utils';
+
+const DynamicRoot = React.lazy(() => import('../DynamicRoot/DynamicRoot'));
+const mockAppInner = () => <AppBase />;
+const MockApp = () => (
+  <React.Suspense fallback={null}>
+    <DynamicRoot
+      apis={[]}
+      afterInit={async () =>
+        Promise.resolve({
+          default: mockAppInner,
+        })
+      }
+    />
+  </React.Suspense>
+);
+
+// Swap out the app's BrowserRouter and provide tests a
+// means to set the initial history
+let initialEntries = ['/'];
+
+const reactRouter = require('react-router-dom');
+
+const { MemoryRouter } = reactRouter;
+
+const MockRouter = ({ children }: any) => (
+  <MemoryRouter initialEntries={[...initialEntries]}>{children}</MemoryRouter>
+);
+MockRouter.propTypes = { ...MemoryRouter.propTypes };
+reactRouter.BrowserRouter = MockRouter;
+
+jest.mock('@scalprum/core', () => ({
+  ...jest.requireActual('@scalprum/core'),
+  getScalprum: jest.fn().mockReturnValue({ api: {} }),
+}));
+
+jest.mock('@scalprum/react-core', () => ({
+  ...jest.requireActual('@scalprum/react-core'),
+  ScalprumProvider: jest
+    .fn()
+    .mockImplementation(({ children }) => <>{children}</>),
+  useScalprum: jest
+    .fn()
+    .mockReturnValue({ initialized: true, pluginStore: [] }),
+}));
+
+jest.mock('react-use/lib/useAsync', () => ({
+  default: () => ({}),
+  __esModule: true,
+}));
+
+jest.mock('@backstage/app-defaults', () => ({
+  ...jest.requireActual('@backstage/app-defaults'),
+  __esModule: true,
+}));
+
+// Remove the sign-in page
+jest.mock('../DynamicRoot/defaultAppComponents', () => ({
+  default: {},
+  __esModule: true,
+}));
+
+// Simplify the home page
+jest.mock('../home/HomePage', () => ({
+  HomePage: () => <></>,
+  __esModule: true,
+}));
+
+// Ensure the correct configuration is picked up by the rendered app
+jest.mock('@backstage/config', () => {
+  const oldModule = jest.requireActual('@backstage/config');
+  const OldConfigReader = oldModule.ConfigReader;
+  const FakeConfigReader = class {
+    _instance: any = undefined;
+    constructor(args: any) {
+      this._instance = new OldConfigReader(args);
+    }
+    static fromConfigs(args: any) {
+      const answer = OldConfigReader.fromConfigs([
+        ...[Array.isArray(args) ? args : []],
+        ...(process.env.APP_CONFIG as any),
+      ]);
+      return answer;
+    }
+  };
+  return {
+    ...oldModule,
+    ConfigReader: FakeConfigReader,
+    __esModule: true,
+  };
+});
+
+const mockInitializeRemotePlugins = jest.fn() as jest.MockedFunction<
+  typeof initializeRemotePlugins
+>;
+jest.mock('../../utils/dynamicUI/initializeRemotePlugins', () => ({
+  default: mockInitializeRemotePlugins,
+  __esModule: true,
+}));
+
+const mockProcessEnv = (dynamicPluginsConfig: { [key: string]: any }) => ({
+  NODE_ENV: 'test',
+  APP_CONFIG: [
+    {
+      data: {
+        app: { title: 'Test' },
+        backend: { baseUrl: 'http://localhost:7007' },
+        techdocs: {
+          storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
+        },
+        auth: { environment: 'development' },
+        dynamicPlugins: {
+          frontend: dynamicPluginsConfig,
+        },
+      },
+      context: 'test',
+    },
+  ] as any,
+});
+
+const consoleSpy = jest.spyOn(console, 'warn');
+
+describe('AdminPage', () => {
+  beforeEach(() => {
+    removeScalprum();
+    mockInitializeRemotePlugins.mockResolvedValue({
+      'test-plugin': {
+        PluginRoot: {
+          default: Fragment,
+          testPlugin: createPlugin({
+            id: 'test-plugin',
+            routes: { root: createRouteRef({ id: 'test-plugin' }) },
+          }),
+          TestComponent: Fragment,
+          isTestConditionTrue: () => true,
+          isTestConditionFalse: () => false,
+          TestComponentWithStaticJSX: {
+            element: ({ children }) => <>{children}</>,
+            staticJSXContent: <div />,
+          },
+        },
+      },
+    });
+    jest
+      .spyOn(useAsync, 'default')
+      .mockReturnValue({ loading: false, value: {} });
+  });
+
+  afterEach(() => {
+    consoleSpy.mockReset();
+  });
+
+  it('Should not be available when not configured', async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [],
+        mountPoints: [],
+      },
+    });
+    initialEntries = ['/'];
+    const rendered = await renderWithEffects(<MockApp />);
+    expect(rendered.baseElement).toBeInTheDocument();
+    const home = rendered.queryByText('Home');
+    const administration = rendered.queryByText('Administration');
+    expect(home).not.toBeNull();
+    expect(administration).toBeNull();
+  });
+
+  it('Should be available when configured', async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [{ path: '/admin/plugins' }],
+        mountPoints: [{ mountPoint: 'admin.page.plugins/cards' }],
+      },
+    });
+    initialEntries = ['/'];
+    const rendered = await renderWithEffects(<MockApp />);
+    expect(rendered.baseElement).toBeInTheDocument();
+    const home = rendered.queryByText('Home');
+    const administration = rendered.queryByText('Administration');
+    expect(home).not.toBeNull();
+    expect(administration).not.toBeNull();
+  });
+
+  it('Should route to the plugin tab when configured', async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [{ path: '/admin/plugins' }],
+        mountPoints: [{ mountPoint: 'admin.page.plugins/cards' }],
+      },
+    });
+    initialEntries = ['/'];
+    const rendered = await renderWithEffects(<MockApp />);
+    expect(rendered.baseElement).toBeInTheDocument();
+    await act(() => {
+      rendered.getByText('Administration').click();
+    });
+    const plugins = rendered.queryByText('Plugins');
+    expect(plugins).not.toBeNull();
+  });
+
+  it('Should route to the rbac tab when configured', async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [{ path: '/admin/rbac' }],
+        mountPoints: [{ mountPoint: 'admin.page.rbac/cards' }],
+      },
+    });
+    initialEntries = ['/'];
+    const rendered = await renderWithEffects(<MockApp />);
+    expect(rendered.baseElement).toBeInTheDocument();
+    await act(() => {
+      rendered.getByText('Administration').click();
+    });
+    const rbac = rendered.queryByText('RBAC');
+    expect(rbac).not.toBeNull();
+  });
+
+  it("Should fail back to the default tab if the currently routed tab doesn't match the configuration", async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [{ path: '/admin/rbac' }],
+        mountPoints: [{ mountPoint: 'admin.page.rbac/cards' }],
+      },
+    });
+    initialEntries = ['/admin/plugins'];
+    const rendered = await renderWithEffects(<MockApp />);
+    // When debugging this test it can be handy to see the entire rendered output
+    // process.stdout.write(`${prettyDOM(rendered.baseElement, 900000)}`);
+    expect(rendered.baseElement).toBeInTheDocument();
+    expect(rendered.getByText('RBAC')).toBeInTheDocument();
+  });
+
+  it('Should fail with an error page if routed to but no configuration is defined', async () => {
+    process.env = mockProcessEnv({
+      'test-plugin': {
+        dynamicRoutes: [],
+        mountPoints: [],
+      },
+    });
+    initialEntries = ['/admin/plugins'];
+    const rendered = await renderWithEffects(<MockApp />);
+    // When debugging this test it can be handy to see the entire rendered output
+    // process.stdout.write(`${prettyDOM(rendered.baseElement, 900000)}`);
+    expect(rendered.baseElement).toBeInTheDocument();
+    const errorComponent = rendered.getByTestId('error');
+    expect(
+      errorComponent.textContent!.indexOf(
+        'No admin mount points are configured',
+      ) !== -1,
+    ).toBeTruthy();
+  });
+});

--- a/packages/app/src/components/admin/AdminPage.tsx
+++ b/packages/app/src/components/admin/AdminPage.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useContext, useEffect } from 'react';
+import {
+  Content,
+  ErrorPage,
+  Header,
+  HeaderTabs,
+  Page,
+} from '@backstage/core-components';
+import DynamicRootContext from '../DynamicRoot/DynamicRootContext';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
+const tabs = [
+  {
+    id: 'rbac',
+    label: 'RBAC',
+    tabProps: { to: '/admin/rbac', component: Link },
+  },
+  {
+    id: 'plugins',
+    label: 'Plugins',
+    tabProps: { to: `/admin/plugins`, component: Link },
+  },
+];
+
+export const AdminPage = () => {
+  const { mountPoints } = useContext(DynamicRootContext);
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const [parent, selectedTab] = pathname.slice(1, pathname.length).split('/');
+  const availableTabs = tabs.filter(({ id }) => {
+    return typeof mountPoints[`admin.page.${id}/cards`] !== 'undefined';
+  });
+  const invalidTab = useCallback(
+    (name: string) =>
+      name === undefined ||
+      availableTabs.find(tab => tab.id === name) === undefined,
+    [availableTabs],
+  );
+  // cater for the edge case where the component renders but the app has not
+  // been configured to have tabs.
+  const { id: defaultTabId } = availableTabs[0] || { id: undefined };
+  useEffect(() => {
+    // deal with use cases where the configuration may change and leave the user
+    // on a tab that is no longer configured.
+    if (defaultTabId && invalidTab(selectedTab)) {
+      navigate(`/${parent}/${defaultTabId}`, { replace: true });
+    }
+  }, [defaultTabId, invalidTab, navigate, parent, selectedTab]);
+  if (availableTabs.length === 0) {
+    // this page shouldn't be routed to if there's no mount points for
+    // it, but there's one edge case where it can happen
+    return (
+      <ErrorPage
+        status="no content available"
+        statusMessage="No admin mount points are configured"
+      />
+    );
+  }
+  if (invalidTab(selectedTab)) {
+    // in this case the page will navigate to a tab, so avoid
+    // doing anything else
+    return <></>;
+  }
+  const selectedIndex = availableTabs.findIndex(tab => tab.id === selectedTab);
+  const tabContent = (
+    mountPoints[`admin.page.${selectedTab}/context`] || []
+  ).reduce(
+    (acc, { Component }) => <Component>{acc}</Component>,
+    <Grid container>
+      {(mountPoints[`admin.page.${selectedTab}/cards`] || []).map(
+        ({ Component, config = {}, staticJSXContent }) => {
+          return (
+            <Box key={`${Component.name}`} sx={config.layout}>
+              <Component {...config.props}>{staticJSXContent}</Component>
+            </Box>
+          );
+        },
+      )}
+    </Grid>,
+  );
+  return (
+    <Page themeId="theme">
+      <Header title="Administration" />
+      <HeaderTabs selectedIndex={selectedIndex} tabs={availableTabs} />
+      <Content>{tabContent}</Content>
+    </Page>
+  );
+};


### PR DESCRIPTION
## Description

This change adds a Administration navigation tab and page intended for plugins that are for administration of an Janus/RHDH instance.  This commit adds two routes /admin/rbac and /admin/plugins and related mountpoints so that dynamic plugins can contribute UI components to this page.  The page can also deal with a few edge cases and will also not be visible should no plugins be configured to show up on it.  A test is provided that covers these cases.  This change also adds the dynamic-plugins-info dynamic plugin which is one of two components intended to appear on this page.

## Which issue(s) does this PR fix

Part of [RHIDP-980](https://issues.redhat.com/browse/RHIDP-980).  This is an approach to provide a home for dynamic plugins that fall under the "Administration" tab, for example:

![image](https://github.com/janus-idp/backstage-showcase/assets/351660/9ae23e90-5e9d-462c-a684-517792a1684c)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
The dynamic-plugins-info plugin is added to the showcase

To enable the Administration tab and see the installed dynamic plugins, use the following configuration in your `app-config.local.yaml` to enable the "Administration" nav and "Plugins" tab:

```yaml
dynamicPlugins:
  frontend:
    janus-idp.backstage-plugin-dynamic-plugins-info:
      dynamicRoutes:
        - path: /admin/plugins
          importName: DynamicPluginsInfo
      mountPoints:
        - mountPoint: admin.page.plugins/cards
          importName: DynamicPluginsInfo
          config:
            layout:
              gridColumn: "1 / -1"
              width: 100vw
```

It should be possible to browse the list of installed plugins using the pagination arrows:

![image](https://github.com/janus-idp/backstage-showcase/assets/351660/f292d41d-fe51-4587-8bba-92ff6d2d3af2)

and searching should work:

![image](https://github.com/janus-idp/backstage-showcase/assets/351660/281e2c01-919b-4985-9720-c64e20161b08)

Removing the configuration for the tab/plugin shouldn't leave the user with a blank page:

![image](https://github.com/janus-idp/backstage-showcase/assets/351660/5dccd59c-a7c1-4e02-a293-1dcea5cf73f2)

