### PR TITLE
fix: downgrade ArgoCD frontend plugin, upstream regression

### DIFF
--- a/.changeset/smooth-pumas-argue.md
+++ b/.changeset/smooth-pumas-argue.md
@@ -1,0 +1,5 @@
+---
+'roadiehq-backstage-plugin-argo-cd': patch
+---
+
+Downgrade ArgoCD frontend plugin to a working state due to https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1238

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-argo-cd",
-  "version": "2.5.1",
+  "version": "2.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "export-dynamic": "janus-cli package export-dynamic-plugin"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-argo-cd": "2.5.1"
+    "@roadiehq/backstage-plugin-argo-cd": "2.4.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.25.1",


### PR DESCRIPTION
## Description

There seems to be an upstream regression https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1238 that renders the `EntityArgoCDHistoryCard` unusable when ArgoCD plugin is used as both the frontend and backend plugin. I hope a version downgrade in a wrapped dynamic plugin is possible since this package is included in the image statically anyways and it is not published.

This is a temporary workaround, not a fix.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
