### PR TITLE
fix(3scale): modify 3scale environment variables

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -530,8 +530,8 @@ plugins:
         providers:
           threeScaleApiEntity:
             default:
-              baseUrl: '${3SCALE_BASE_URL}'
-              accessToken: '${3SCALE_ACCESS_TOKEN}'
+              baseUrl: '${_3SCALE_BASE_URL}'
+              accessToken: '${_3SCALE_ACCESS_TOKEN}'
 
   - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-keycloak-backend-dynamic
     disabled: true


### PR DESCRIPTION
## Description

We must change 3Scale plugin environment variables because it does not comply with Openshift and POSIX standards for environment variables (Must not start with a digit).

Please explain the changes you made here.

Just added an underscore ("_") to the variables name.

## Which issue(s) does this PR fix

- Fixes #?

JIRA: https://issues.redhat.com/browse/RHIDP-1030
Fixes https://github.com/janus-idp/backstage-showcase/issues/849

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
