### PR TITLE
docs: Document how to set up monitoring and logging on OpenShift when using the operator

### DIFF
--- a/showcase-docs/monitoring-and-logging.md
+++ b/showcase-docs/monitoring-and-logging.md
@@ -195,7 +195,11 @@ InsightsMetrics
 
 ## Logging
 
-Logging in backstage showcase is conducted using the [winston](https://github.com/winstonjs/winston) library. By default, logs of level `debug` are not logged. To enable debug logs, you will need to set the environment variable `LOG_LEVEL` to `debug` in your deployment in the helm chart's `values.yaml` as follows:
+Logging in backstage showcase is conducted using the [winston](https://github.com/winstonjs/winston) library. By default, logs of level `debug` are not logged. To enable debug logs, you will need to set the environment variable `LOG_LEVEL` to `debug` in your deployment.
+
+### Helm deployment
+
+You can set the logging level by adding the environment variable in your Helm chart's `values.yaml`, as follows:
 
 ```yaml title="values.yaml"
 upstream:
@@ -204,6 +208,20 @@ upstream:
     extraEnvVars:
       - name: LOG_LEVEL
         value: debug
+```
+
+### Operator-backed deployment
+
+You can set the logging level by adding the environment variable in your Custom Resource, like so:
+
+```yaml title="env var in Custom Resource"
+spec:
+  # Other fields omitted
+  application:
+    extraEnvs:
+      envs:
+        - name: LOG_LEVEL
+          value: debug
 ```
 
 ### Openshift Logging Integration


### PR DESCRIPTION
## Description

This extends the existing documentation [Setting up Metrics Monitoring and Logging for Backstage Showcase](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/monitoring-and-logging.md?rgh-link-date=2024-01-31T12%3A01%3A44Z) with the information on how to configure this when RHDH is deployed using the operator.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-1142
- Fixes https://github.com/janus-idp/operator/issues/180

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
- Follow the operator instructions to install the operator and install RHDH on OpenShift: https://github.com/janus-idp/operator/blob/main/.rhdh/docs/installing-ci-builds.adoc
- Follow the documentation in this PR to try it out