### PR TITLE
[rbac]: added playwright e2e tests

### DIFF
--- a/.ibm/pipelines/openshift-tests.sh
+++ b/.ibm/pipelines/openshift-tests.sh
@@ -127,6 +127,7 @@ apply_yaml_files() {
   # re-apply with the updated cluster service account token
   oc apply -f $dir/auth/secrets-rhdh-secrets.yaml --namespace=${NAME_SPACE}
   oc apply -f $dir/resources/config_map/configmap-app-config-rhdh.yaml --namespace=${NAME_SPACE}
+  oc apply -f $dir/resources/config_map/configmap-rbac-policy-rhdh.yaml --namespace=${NAME_SPACE}
 }
 
 run_tests() {

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -83,6 +83,10 @@ data:
           target: https://github.com/janus-qe/rhdh-test/blob/main/user.yml
           rules:
             - allow: [User]
+        - type: url
+          target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+          rules:
+            - allow: [User, Group]
 
 
     dynatrace:
@@ -97,4 +101,11 @@ data:
             - name: argoInstance2
               url: temp
               token: temp
+    permission:
+      enabled: true
+      rbac:
+        policies-csv-file: './rbac/rbac-policy.csv'
+        admin:
+          users:
+            - name: user:default/rhdh-qe 
 

--- a/.ibm/pipelines/resources/config_map/configmap-rbac-policy-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-rbac-policy-rhdh.yaml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rbac-policy
+data:
+  rbac-policy.csv: |
+    p, role:default/guests, catalog.entity.create, create, allow
+    p, role:default/team_a, catalog-entity, read, allow
+    g, user:xyz/user, role:xyz/team_a
+
+    p, role:xyz/team_a, catalog-entity, read, allow
+    p, role:xyz/team_a, catalog.entity.create, create, allow
+    p, role:xyz/team_a, catalog.location.create, create, allow
+    p, role:xyz/team_a, catalog.location.read, read, allow
+
+    p, role:default/rbac_admin, kubernetes.proxy, use, allow
+    p, role:default/rbac_admin, catalog-entity, read, allow
+    p, role:default/rbac_admin, catalog.entity.create, create, allow
+    p, role:default/rbac_admin, catalog.location.create, create, allow
+    p, role:default/rbac_admin, catalog.location.read, read, allow

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -94,6 +94,8 @@ global:
           disabled: false
         - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-acr
           disabled: false
+        - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-rbac
+          disabled: false
 
 
   # this value will be overriden by 'helm install .... --set global.clusterRouterBase=value'
@@ -191,12 +193,18 @@ upstream:
       # The initContainer below will install dynamic plugins in this volume mount.
       - name: dynamic-plugins-root
         mountPath: /opt/app-root/src/dynamic-plugins-root
+      - name: rbac-policy
+        mountPath: /opt/app-root/src/rbac
     extraVolumes:
       # -- Ephemeral volume that will contain the dynamic plugins installed by the initContainer below at start.
       # To have more control on underlying storage, the [emptyDir](https://docs.openshift.com/container-platform/4.13/storage/understanding-ephemeral-storage.html)
       # could be changed to a [generic ephemeral volume](https://docs.openshift.com/container-platform/4.13/storage/generic-ephemeral-vols.html#generic-ephemeral-vols-procedure_generic-ephemeral-volumes).
       - name: dynamic-plugins-root
         emptyDir: {}
+      - name: rbac-policy
+        configMap: 
+          defaultMode: 420
+          name: rbac-policy
 
       # Volume that will expose the `dynamic-plugins.yaml` file from the `dynamic-plugins` config map.
       # The `dynamic-plugins` config map is created by the helm chart from the content of the `global.dynamic` field.

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -6,6 +6,7 @@ import {
   BackstageShowcase,
   CatalogImport,
 } from '../support/pages/CatalogImport';
+import { templates } from '../support/testData/templates';
 
 let page: Page;
 test.describe.serial('GitHub Happy path', () => {
@@ -72,6 +73,17 @@ test.describe.serial('GitHub Happy path', () => {
     ]);
     await uiHelper.selectMuiBox('Kind', 'System');
     await uiHelper.verifyRowsInTable(['Janus-IDP']);
+  });
+
+  test('Verify all 12 Software Templates appear in the Create page', async () => {
+    await uiHelper.openSidebar('Create...');
+    await uiHelper.verifyHeading('Templates');
+    await uiHelper.waitForHeaderTitle();
+
+    for (const template of templates) {
+      await uiHelper.waitForH4Title(template);
+      await uiHelper.verifyHeading(template);
+    }
   });
 
   test('Click login on the login popup and verify that Overview tab renders', async () => {

--- a/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
@@ -2,7 +2,6 @@ import { test } from '@playwright/test';
 import { UIhelper } from '../utils/UIhelper';
 import { HomePage } from '../support/pages/HomePage';
 import { Common } from '../utils/Common';
-import { templates } from '../support/testData/templates';
 
 test.describe('Guest Signing Happy path', () => {
   let uiHelper: UIhelper;
@@ -22,33 +21,11 @@ test.describe('Guest Signing Happy path', () => {
     await homePage.verifyQuickAccess('Developer Tools', 'Podman Desktop');
   });
 
-  test.skip('Verify Catalog page renders with no components', async () => {
+  test('Verify Catalog page renders with no components', async () => {
     await uiHelper.openSidebar('Catalog');
     await uiHelper.verifyHeading('My Org Catalog');
     await uiHelper.selectMuiBox('Kind', 'Component');
-    // Check if there are no records to display.
-  });
-
-  test('Verify that all users in your Github Organization have been ingested into the Catalog Page', async () => {
-    await uiHelper.openSidebar('Catalog');
-    await uiHelper.selectMuiBox('Kind', 'user');
-    await uiHelper.verifyRowsInTable([
-      'Subhash Khileri',
-      'Joseph Kim',
-      'Gustavo Lira e Silva',
-      'rhdh-qe',
-    ]);
-  });
-
-  test('Verify all 12 Software Templates appear in the Create page', async () => {
-    await uiHelper.openSidebar('Create...');
-    await uiHelper.verifyHeading('Templates');
-    await uiHelper.waitForHeaderTitle();
-
-    for (const template of templates) {
-      await uiHelper.waitForH4Title(template);
-      await uiHelper.verifyHeading(template);
-    }
+    await uiHelper.verifyText('No records to display');
   });
 
   test('Verify Profile is Guest in the Settings page', async () => {

--- a/e2e-tests/playwright/e2e/plugins/acr.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/acr.spec.ts
@@ -15,7 +15,7 @@ test.describe('Test ACR plugin', () => {
 
     uiHelper = new UIhelper(page);
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.loginAsGithubUser();
   });
 
   test('Verify ACR Images are visible', async () => {

--- a/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
@@ -29,9 +29,9 @@ test.describe.serial('Test OCM plugin', () => {
     uiHelper = new UIhelper(page);
     clusters = new Clusters(page);
 
-    await common.loginAsGuest();
+    await common.loginAsGithubUser();
   });
-  test('Navigate to Clusters and Verify OCM Clusters', async () => {
+  test.skip('Navigate to Clusters and Verify OCM Clusters', async () => {
     await uiHelper.openSidebar('Clusters');
     await uiHelper.verifyRowInTableByUniqueText(clusterDetails.clusterName, [
       clusterDetails.status,

--- a/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
@@ -8,7 +8,7 @@ test.describe('Test Quay.io plugin', () => {
 
   test.beforeEach(async ({ page }) => {
     const common = new Common(page);
-    await common.loginAsGuest();
+    await common.loginAsGithubUser();
   });
 
   test('Check if Image Registry is present', async ({ page }) => {

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -1,0 +1,131 @@
+import { test, Page, expect } from '@playwright/test';
+import { UIhelper } from '../../../utils/UIhelper';
+import { Common } from '../../../utils/Common';
+import { Roles } from '../../../support/pages/rbac';
+import {
+  HomePagePO,
+  RoleFormPO,
+  RoleListPO,
+  RoleOverviewPO,
+} from '../../../support/pageObjects/page-obj';
+import { UIhelperPO } from '../../../support/pageObjects/global-obj';
+
+test.describe.serial('Test RBAC plugin as an admin user', () => {
+  let common: Common;
+  let uiHelper: UIhelper;
+  let page: Page;
+  let rolesHelper: Roles;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+
+    uiHelper = new UIhelper(page);
+    common = new Common(page);
+    rolesHelper = new Roles(page);
+    await common.loginAsGithubUser();
+    await uiHelper.openSidebar('Administration');
+    await uiHelper.verifyHeading('Administration');
+    await uiHelper.verifyLink('RBAC');
+    await uiHelper.clickTab('RBAC');
+  });
+
+  test('Check if Administration side nav is present with RBAC tab', async () => {
+    await uiHelper.verifyHeading('All roles (2)');
+    const allGridColumnsText = Roles.getRolesListColumnsText();
+    await uiHelper.verifyColumnHeading(allGridColumnsText);
+    const allCellsIdentifier = Roles.getRolesListCellsIdentifier();
+    await uiHelper.verifyCellsInTable(allCellsIdentifier);
+  });
+
+  test('View details of a role', async () => {
+    await uiHelper.clickLink('role:default/rbac_admin');
+
+    await uiHelper.verifyHeading('role:default/rbac_admin');
+    await uiHelper.clickTab('Overview');
+
+    await uiHelper.verifyText('About');
+
+    await uiHelper.verifyHeading('Users and groups (1 user');
+    const usersAndGroupsColumnsText = Roles.getUsersAndGroupsListColumnsText();
+    await uiHelper.verifyColumnHeading(usersAndGroupsColumnsText);
+    const usersAndGroupsCellsIdentifier =
+      Roles.getUsersAndGroupsListCellsIdentifier();
+    await uiHelper.verifyCellsInTable(usersAndGroupsCellsIdentifier);
+
+    await uiHelper.verifyHeading('Permission policies (9)');
+    const permissionPoliciesColumnsText =
+      Roles.getPermissionPoliciesListColumnsText();
+    await uiHelper.verifyColumnHeading(permissionPoliciesColumnsText);
+    const permissionPoliciesCellsIdentifier =
+      Roles.getPermissionPoliciesListCellsIdentifier();
+    await uiHelper.verifyCellsInTable(permissionPoliciesCellsIdentifier);
+
+    await uiHelper.clickLink('RBAC');
+  });
+
+  test.skip('Create and edit a role from the roles list page', async () => {
+    await rolesHelper.createRole('test-role');
+    await page.click(RoleListPO.editRole('role:default/test-role'));
+    await uiHelper.verifyHeading('Edit Role');
+    await uiHelper.clickButton('Next');
+    await page.fill(RoleFormPO.addUsersAndGroups, 'Jonathon Page');
+    await page.click(RoleFormPO.selectMember('Jonathon Page'));
+    await uiHelper.verifyHeading('Users and groups (3 users, 1 group)');
+    await uiHelper.clickButton('Next');
+    await uiHelper.clickButton('Next');
+    await uiHelper.clickButton('Save');
+
+    await page.locator(HomePagePO.searchBar).waitFor({ state: 'visible' });
+    await page.locator(HomePagePO.searchBar).fill('test-role');
+    await uiHelper.verifyHeading('All roles (1)');
+    const usersAndGroupsLocator = page
+      .locator(UIhelperPO.MuiTableCell)
+      .filter({ hasText: '3 users, 1 group' });
+    await usersAndGroupsLocator.waitFor();
+    await expect(usersAndGroupsLocator).toBeVisible();
+
+    await rolesHelper.deleteRole('role:default/test-role');
+  });
+
+  test.skip('Edit users and groups and update policies of a role from the overview page', async () => {
+    await rolesHelper.createRole('test-role1');
+    await uiHelper.clickLink('role:default/test-role1');
+
+    await uiHelper.verifyHeading('role:default/test-role1');
+    await uiHelper.clickTab('Overview');
+
+    await page.click(RoleOverviewPO.updateMembers);
+    await uiHelper.verifyHeading('Edit Role');
+    await page.locator(HomePagePO.searchBar).fill('Guest User');
+    await page.click('button[aria-label="Remove"]');
+    await uiHelper.verifyHeading('Users and groups (1 user, 1 group)');
+    await uiHelper.clickButton('Next');
+    await uiHelper.clickButton('Next');
+    await uiHelper.clickButton('Save');
+    await uiHelper.verifyText(
+      'Role role:default/test-role1 updated successfully',
+    );
+    await uiHelper.verifyHeading('Users and groups (1 user, 1 group)');
+
+    await page.click(RoleOverviewPO.updatePolicies);
+    await uiHelper.verifyHeading('Edit Role');
+    await page.click(RoleFormPO.addPermissionPolicy);
+    await page.click(RoleFormPO.selectPermissionPolicyPlugin(1), {
+      timeout: 100000,
+    });
+    await uiHelper.optionSelector('scaffolder');
+    await page.click(RoleFormPO.selectPermissionPolicyPermission(1));
+    await uiHelper.optionSelector('scaffolder-template');
+    await uiHelper.clickButton('Next');
+    await uiHelper.clickButton('Save');
+    await uiHelper.verifyText(
+      'Role role:default/test-role1 updated successfully',
+    );
+    await uiHelper.verifyHeading('Permission Policies (3)');
+
+    await rolesHelper.deleteRole('role:default/test-role1');
+  });
+  test.afterAll(async () => {
+    await page.close();
+  });
+});

--- a/e2e-tests/playwright/e2e/techdocs.spec.ts
+++ b/e2e-tests/playwright/e2e/techdocs.spec.ts
@@ -9,7 +9,7 @@ test.describe.serial('TechDocs', () => {
   test.beforeEach(async ({ page }) => {
     uiHelper = new UIhelper(page);
     common = new Common(page);
-    await common.loginAsGuest();
+    await common.loginAsGithubUser();
   });
 
   test('Verify that TechDocs is visible in sidebar', async () => {

--- a/e2e-tests/playwright/support/pageObjects/global-obj.ts
+++ b/e2e-tests/playwright/support/pageObjects/global-obj.ts
@@ -4,7 +4,7 @@ export const waitsObjs = {
 };
 
 export const UIhelperPO = {
-  buttonLabel: 'span[class^="MuiButton-label"]',
+  MuiButtonLabel: 'span[class^="MuiButton-label"]',
   MuiBoxLabel: 'div[class*="MuiBox-root"] label',
   MuiTableCell: 'td[class*="MuiTableCell-root"]',
   MuiTableRow: 'tr[class*="MuiTableRow-root"]',
@@ -12,6 +12,9 @@ export const UIhelperPO = {
     `//div[contains(@class,'MuiCardHeader-root') and descendant::*[text()='${cardHeading}']]/..`,
   MuiTable: 'table.MuiTable-root',
   MuiCardHeader: 'div[class*="MuiCardHeader-root"]',
+  MuiInputBase: 'div[class*="MuiInputBase-root"]',
+  MuiTypography: 'span[class*="MuiTypography-root"]',
+  MuiAlert: 'div[class*="MuiAlert-message"]',
   tabs: '[role="tab"]',
   rowByText: (text: string) => `tr:has(:text-is("${text}"))`,
 };

--- a/e2e-tests/playwright/support/pageObjects/page-obj.ts
+++ b/e2e-tests/playwright/support/pageObjects/page-obj.ts
@@ -20,3 +20,31 @@ export const SettingsPagePO = {
   userSettingsMenu: 'button[data-testid="user-settings-menu"]',
   signOut: 'li[data-testid="sign-out"]',
 };
+
+export const RoleFormPO = {
+  roleName: 'input[name="name"]',
+  roledescription: 'input[name="description"]',
+  addUsersAndGroups: 'input[name="add-users-and-groups"]',
+  addPermissionPolicy: 'button[name="add-permission-policy"]',
+  selectMember: (label: string) => `span[data-testid="${label}"]`,
+  selectPermissionPolicyPlugin: (row: number) =>
+    `input[name="permissionPoliciesRows[${row}].plugin"]`,
+  selectPermissionPolicyPermission: (row: number) =>
+    `input[name="permissionPoliciesRows[${row}].permission"]`,
+  selectPolicy: (row: number, policy: number, policyName: string) =>
+    `input[name="permissionPoliciesRows[${row}].policies[${policy}].policy-${policyName}"]`,
+};
+
+export const RoleListPO = {
+  editRole: (name: string) => `span[data-testid="update-role-${name}"]`,
+  deleteRole: (name: string) => `span[data-testid="delete-role-${name}"]`,
+};
+
+export const DeleteRolePO = {
+  roleName: 'input[name="delete-role"]',
+};
+
+export const RoleOverviewPO = {
+  updatePolicies: 'span[data-testid="update-policies"]',
+  updateMembers: 'span[data-testid="update-members"]',
+};

--- a/e2e-tests/playwright/support/pages/rbac.ts
+++ b/e2e-tests/playwright/support/pages/rbac.ts
@@ -1,0 +1,104 @@
+import { Page } from '@playwright/test';
+import { UIhelper } from '../../utils/UIhelper';
+import {
+  DeleteRolePO,
+  HomePagePO,
+  RoleFormPO,
+  RoleListPO,
+} from '../pageObjects/page-obj';
+
+export class Roles {
+  private page: Page;
+  private uiHelper: UIhelper;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.uiHelper = new UIhelper(page);
+  }
+  static getRolesListCellsIdentifier() {
+    const roleName = new RegExp(/^(role|user|group):[a-zA-Z]+\/[\w@*.~-]+$/);
+    const usersAndGroups = new RegExp(
+      /^(1\s(user|group)|[2-9]\s(users|groups))(, (1\s(user|group)|[2-9]\s(users|groups)))?$/,
+    );
+    const permissionPolicies = /\d/;
+    return [roleName, usersAndGroups, permissionPolicies];
+  }
+
+  static getUsersAndGroupsListCellsIdentifier() {
+    const name = new RegExp(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/);
+    const type = new RegExp(/^(User|Group)$/);
+    const members = /^(-|\d+)$/;
+    return [name, type, members];
+  }
+
+  static getPermissionPoliciesListCellsIdentifier() {
+    const policies =
+      /^(?:(Read|Create|Update|Delete)(?:, (?:Read|Create|Update|Delete))*|Use)$/;
+    return [policies];
+  }
+
+  static getRolesListColumnsText() {
+    return ['Name', 'Users and groups', 'Permission Policies', 'Actions'];
+  }
+
+  static getUsersAndGroupsListColumnsText() {
+    return ['Name', 'Type', 'Members'];
+  }
+
+  static getPermissionPoliciesListColumnsText() {
+    return ['Plugin', 'Permission', 'Policies'];
+  }
+
+  async createRole(name: string) {
+    await this.uiHelper.clickButton('Create');
+
+    await this.uiHelper.verifyHeading('Create role');
+
+    await this.page.fill(RoleFormPO.roleName, name);
+    await this.uiHelper.clickButton('Next');
+    await this.page.fill(RoleFormPO.addUsersAndGroups, 'guest user');
+    await this.page.click(RoleFormPO.selectMember('Guest User'));
+    await this.page.fill(RoleFormPO.addUsersAndGroups, 'tara');
+    await this.page.click(RoleFormPO.selectMember('Tara MacGovern'));
+    await this.page.fill(RoleFormPO.addUsersAndGroups, 'Backstage');
+    await this.page.click(RoleFormPO.selectMember('Backstage'));
+    await this.uiHelper.verifyHeading('Users and groups (2 users, 1 group)');
+    await this.uiHelper.clickButton('Next');
+
+    await this.page.click(RoleFormPO.selectPermissionPolicyPlugin(0), {
+      timeout: 100000,
+    });
+    await this.uiHelper.optionSelector('catalog');
+    await this.page.click(RoleFormPO.selectPermissionPolicyPermission(0));
+    await this.uiHelper.optionSelector('catalog-entity');
+    await this.page.uncheck(RoleFormPO.selectPolicy(0, 1, 'Delete'));
+
+    await this.uiHelper.clickButton('Next');
+
+    await this.uiHelper.verifyHeading('Review and create');
+    await this.uiHelper.verifyText('Users and groups (2 users, 1 group)');
+    await this.uiHelper.verifyText('Permission policies (2)');
+
+    await this.uiHelper.clickButton('Create');
+
+    await this.page.locator(HomePagePO.searchBar).waitFor({ timeout: 60000 });
+    await this.page.locator(HomePagePO.searchBar).fill(name);
+    await this.uiHelper.verifyHeading('All roles (1)');
+  }
+
+  async deleteRole(name: string) {
+    await this.uiHelper.openSidebar('Administration');
+    await this.uiHelper.clickTab('RBAC');
+    const button = this.page.locator(RoleListPO.deleteRole(name));
+    await button.waitFor({ state: 'visible' });
+    await button.click();
+    await this.uiHelper.verifyHeading('Delete this role?');
+    await this.page.locator(DeleteRolePO.roleName).click();
+    await this.page.fill(DeleteRolePO.roleName, name);
+    await this.uiHelper.clickButton('Delete');
+
+    await this.uiHelper.verifyText(`Role ${name} deleted successfully`);
+    await this.page.locator(HomePagePO.searchBar).fill(name);
+    await this.uiHelper.verifyHeading('All roles (0)');
+  }
+}

--- a/e2e-tests/playwright/utils/UIhelper.ts
+++ b/e2e-tests/playwright/utils/UIhelper.ts
@@ -18,9 +18,18 @@ export class UIhelper {
     await this.page.waitForSelector('h2[data-testid="header-title"]');
   }
 
-  async clickButton(label: string, options?: { force?: boolean }) {
-    const selector = `${UIhelperPO.buttonLabel}:has-text("${label}")`;
-    const button = this.page.locator(selector);
+  async clickButton(
+    label: string,
+    options: { exact?: boolean; force?: boolean } = {
+      exact: true,
+      force: false,
+    },
+  ) {
+    const selector = `${UIhelperPO.MuiButtonLabel}:has-text("${label}")`;
+    const button = this.page
+      .locator(selector)
+      .getByText(label, { exact: options.exact })
+      .first();
     await button.waitFor({ state: 'visible' });
 
     if (options?.force) {
@@ -34,7 +43,7 @@ export class UIhelper {
     label: string,
     options: { timeout: number } = { timeout: 40000 },
   ) {
-    const selector = `${UIhelperPO.buttonLabel}`;
+    const selector = `${UIhelperPO.MuiButtonLabel}`;
     await this.page.waitForSelector(selector, { timeout: options.timeout });
     return this.page.locator(selector).filter({ hasText: label });
   }
@@ -93,21 +102,6 @@ export class UIhelper {
     await this.page.click(`nav a:has-text("${navBarText}")`);
   }
 
-  async verifyColumnHeading(
-    rowTexts: string[] | RegExp[],
-    exact: boolean = true,
-  ) {
-    for (const rowText of rowTexts) {
-      const rowLocator = this.page
-        .locator(`tr>th`)
-        .getByText(rowText, { exact: exact })
-        .first();
-      await rowLocator.waitFor({ state: 'visible' });
-      await rowLocator.scrollIntoViewIfNeeded();
-      await expect(rowLocator).toBeVisible();
-    }
-  }
-
   async selectMuiBox(label: string, value: string) {
     await this.page.click(`div[aria-label="${label}"]`);
     const optionSelector = `li[role="option"]:has-text("${value}")`;
@@ -122,6 +116,21 @@ export class UIhelper {
     for (const rowText of rowTexts) {
       const rowLocator = this.page
         .locator(`tr>td`)
+        .getByText(rowText, { exact: exact })
+        .first();
+      await rowLocator.waitFor({ state: 'visible' });
+      await rowLocator.scrollIntoViewIfNeeded();
+      await expect(rowLocator).toBeVisible();
+    }
+  }
+
+  async verifyColumnHeading(
+    rowTexts: string[] | RegExp[],
+    exact: boolean = true,
+  ) {
+    for (const rowText of rowTexts) {
+      const rowLocator = this.page
+        .locator(`tr>th`)
         .getByText(rowText, { exact: exact })
         .first();
       await rowLocator.waitFor({ state: 'visible' });
@@ -170,8 +179,14 @@ export class UIhelper {
     }
   }
 
+  async optionSelector(value: string) {
+    const optionSelector = `li[role="option"]:has-text("${value}")`;
+    await this.page.waitForSelector(optionSelector);
+    await this.page.click(optionSelector);
+  }
+
   getButtonSelector(label: string): string {
-    return `span[class^="MuiButton-label"]:has-text("${label}")`;
+    return `${UIhelperPO.MuiButtonLabel}:has-text("${label}")`;
   }
 
   async verifyRowInTableByUniqueText(


### PR DESCRIPTION
## Description

- Added playwright e2e tests
- Updated RBAC frontend and backend packages
- Updated existing tests in `guest-signin-happy-path` . Once the RBAC is enabled, catalog components will not be accessible to guest users.
- disabled the ocm e2e tests

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-1340

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

**app-config.local.yaml**

catalog configuration:

```
    - type: url
      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
      rules:
        - allow: [User, Group]
```

permission configuration:

```
permission:
  enabled: true
  rbac:
    policies-csv-file: /<path-to-your-csv-file>/rbac-policy.csv
    policyFileReload: true
    admin:
      users:
        - name: user:default/rhdh-qe
```

dynamic plugins configuration:

```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
    janus-idp.backstage-plugin-rbac:
      mountPoints:
        - mountPoint: admin.page.rbac/cards
          module: RbacPlugin
          importName: RbacPage
          config:
            layout:
              gridColumn: "1 / -1"
              width: 100vw
            props:
              useHeader: false
      dynamicRoutes:
        - path: /admin/rbac
          module: RbacPlugin
          importName: RbacPage
```


**rbac-policy.csv**

```
p, role:default/guests, catalog.entity.create, create, allow

p, role:default/team_a, catalog-entity, read, allow

g, user:xyz/user, role:xyz/team_a

p, role:xyz/team_a, catalog-entity, read, allow
p, role:xyz/team_a, catalog.entity.create, create, allow
p, role:xyz/team_a, catalog.location.create, create, allow
p, role:xyz/team_a, catalog.location.read, read, allow

p, role:default/rbac_admin, kubernetes.proxy, use, allow

```


**Run the following command from `e2e-tests` directory**
```
sudo yarn install
```

**Set the following env variable**

```
export BASE_URL=http://localhost:3000
export GH_USER_ID=rhdh-qe
export GH_USER_PASS=
export GH_2FA_SECRET=
export GH_RHDH_QE_USER_TOKEN=
```

**Start the application**

Run the e2e tests using the following command from **e2e-tests** folder
```
npx playwright test --ui
```


<img width="1376" alt="Screenshot 2024-02-21 at 10 36 49 PM" src="https://github.com/janus-idp/backstage-showcase/assets/22490998/e65d1a79-a3ad-40c4-a98b-46fdb3524178">
