### PR TITLE
Fix MUI Tab console warnings

### DIFF
--- a/.changeset/good-kings-allow.md
+++ b/.changeset/good-kings-allow.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+fix mui tab warnings

--- a/packages/app/src/themes/componentOverrides.ts
+++ b/packages/app/src/themes/componentOverrides.ts
@@ -18,11 +18,14 @@ export const components = (
     BackstageHeaderTabs: {
       styleOverrides: {
         tabsWrapper: {
-          paddingLeft: '0px',
+          paddingLeft: '0',
         },
         defaultTab: {
           textTransform: 'none',
           fontSize: '0.875rem',
+          '&:hover': {
+            boxShadow: '0 -3px #b8bbbe inset',
+          },
         },
       },
     },
@@ -47,13 +50,11 @@ export const components = (
       },
       styleOverrides: {
         root: {
+          textTransform: 'none',
           minWidth: 'initial !important',
-          '&:hover': {
-            boxShadow: '0 -3px #b8bbbe inset',
+          '&.Mui-disabled': {
+            backgroundColor: '#d2d2d2',
           },
-        },
-        disabled: {
-          backgroundColor: '#6a6e73',
         },
       },
     },


### PR DESCRIPTION
Part of: https://github.com/janus-idp/backstage-showcase/pull/960

Fixed 
![Screenshot 2024-02-20 at 12 57 00 AM](https://github.com/janus-idp/backstage-showcase/assets/22490998/4fe5668a-adc3-489c-a650-a543df7caafd)

Fixed the disabled tab color

![Screenshot 2024-02-20 at 11 33 51 AM](https://github.com/janus-idp/backstage-showcase/assets/22490998/fd136dcb-3ee4-44d3-80b4-7684020c82bb)

![Screenshot 2024-02-20 at 11 34 02 AM](https://github.com/janus-idp/backstage-showcase/assets/22490998/913df9cd-bc33-4480-92dc-369840cbe7f7)
