### PR TITLE
Update testCluster specifications and enable OCM test

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
@@ -9,11 +9,10 @@ const clusterDetails = {
   clusterName: 'testCluster',
   status: 'Ready',
   platform: 'IBM',
-  cpuCores: '12',
-  memorySize: '47 Gi',
+  cpuCores: '16',
+  memorySize: '63 Gi',
   ocVersion: /^\d+\.\d+\.\d+$/,
 };
-
 let page: Page;
 test.describe.serial('Test OCM plugin', () => {
   let uiHelper: UIhelper;
@@ -31,7 +30,7 @@ test.describe.serial('Test OCM plugin', () => {
 
     await common.loginAsGithubUser();
   });
-  test.skip('Navigate to Clusters and Verify OCM Clusters', async () => {
+  test('Navigate to Clusters and Verify OCM Clusters', async () => {
     await uiHelper.openSidebar('Clusters');
     await uiHelper.verifyRowInTableByUniqueText(clusterDetails.clusterName, [
       clusterDetails.status,


### PR DESCRIPTION
The OCM (Open Cluster Management) test configurations in the e2e (end-to-end) tests have been updated with new specifications for the testCluster; CPU cores have been increased from 12 to 16, and memory size from 47Gi to 63Gi. Additionally, a previously skipped test "Navigate to Clusters and Verify OCM Clusters" has been enabled for execution.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
