### PR TITLE
Updated how OAuth headers are processed

### DIFF
--- a/docs/configuration-env-variables.md
+++ b/docs/configuration-env-variables.md
@@ -1,0 +1,3 @@
+# Environment Variables
+
+- `OAUTH_USER_HEADER` - HTTP header containing the username for the OAuth 2 Proxy Provider. If not set, it tries `x-forwarded-preferred-username` and `x-forwarded-user`

--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -177,7 +177,10 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
       return providers.oauth2Proxy.create({
         signIn: {
           async resolver({ result }, ctx) {
-            const name = result.getHeader('x-forwarded-preferred-username');
+            const name = process.env.OAUTH_USER_HEADER
+              ? result.getHeader(process.env.OAUTH_USER_HEADER)
+              : result.getHeader('x-forwarded-preferred-username') ||
+                result.getHeader('x-forwarded-user');
             if (!name) {
               throw new Error('Request did not contain a user');
             }


### PR DESCRIPTION
## Description

Ability to define the HTTP header containing the username for the OAuth 2 Proxy Provider

Implements a fallback strategy

1. Environment variable defined by the value of `OAUTH_USER_HEADER`
2. `x-forwarded-preferred-username` HTTP Header (Primary use case: with Keycloak/RHSSO/RHBK)
3. `x-forwarded-user` (Primary use case: OpenShift)

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Make use of a variety of OAuth Providers:

1. Configure OpenShift OAuth based on instructions [here](https://janus-idp.io/blog/2023/02/20/using-openshift-authentication-to-secure-access-to-backstage)
2. Configure Keycloak based on instructions [here](https://janus-idp.io/blog/2023/01/17/enabling-keycloak-authentication-in-backstage)
3. Specify the `OAUTH_USER_HEADER` with a desired header to utilize. You can specify any of the values that are natively provided by the two options previously mentioned

Within the documentation, ignore any details related to customizing the backstage image as the necessary configurations are implemented here