### PR TITLE
chore(admin): enable dynamic-plugins-info

### DIFF
--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -30,8 +30,6 @@ global:
                         seconds: 15
         - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
           disabled: false
-        - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-dynamic-plugins-info
-          disabled: false
         - package:  ./dynamic-plugins/dist/backstage-plugin-github-issues
           disabled: false
         - package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-pull-requests

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -502,7 +502,6 @@ plugins:
   - package: ./dynamic-plugins/dist/janus-idp-backstage-scaffolder-backend-module-regex-dynamic
 
   - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-dynamic-plugins-info
-    disabled: true
     pluginConfig:
       dynamicPlugins:
         frontend:


### PR DESCRIPTION
This change enables the dynamic-plugins-info UI by default when installing the app via helm  or operator.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
