### PR TITLE
Skip Google sign-in e2e test in beforeAll hook

### DIFF
--- a/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
@@ -8,7 +8,7 @@ test.describe('Google signin happy path', () => {
   let common: Common;
   const google_user_id = 'rhdhtest@gmail.com';
 
-  test.beforeAll(async ({ browser }) => {
+  test.beforeAll.skip(async ({ browser }) => {
     const cookiesBase64 = process.env.GOOGLE_ACC_COOKIE;
     const cookiesString = Buffer.from(cookiesBase64, 'base64').toString('utf8');
     const cookies = JSON.parse(cookiesString);


### PR DESCRIPTION
The 'beforeAll' hook in the 'google-signin-happy-path' end-to-end test has been updated to skip the test. This change was necessary to prevent the test from running in certain scenarios where it wasn't needed. The test can be enabled or disabled as required in future.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
