### PR TITLE
Disable Google signin happy path test

### DIFF
--- a/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
@@ -3,12 +3,12 @@ import { Common } from '../utils/Common';
 import { UIhelper } from '../utils/UIhelper';
 
 let page: Page;
-test.describe('Google signin happy path', () => {
+test.describe.skip('Google signin happy path', () => {
   let uiHelper: UIhelper;
   let common: Common;
   const google_user_id = 'rhdhtest@gmail.com';
 
-  test.beforeAll.skip(async ({ browser }) => {
+  test.beforeAll(async ({ browser }) => {
     const cookiesBase64 = process.env.GOOGLE_ACC_COOKIE;
     const cookiesString = Buffer.from(cookiesBase64, 'base64').toString('utf8');
     const cookies = JSON.parse(cookiesString);


### PR DESCRIPTION
The commit removes the skip on 'beforeAll' hook in the 'google-signin-happy-path' end-to-end test. Now, the entire test, including this hook, will be run in our suite. This was done to align with updates in our testing strategy or requirements.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
