### PR TITLE
feat(OIDC): adds a forked version of the OIDC auth plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 plugins
 !plugins/scalprum-backend
 !plugins/dynamic-plugins-info-backend
+!plugins/auth-backend-module-oidc-provider
 *.local.yaml
 coverage
 dist-types

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -52,6 +52,7 @@ COPY $EXTERNAL_SOURCE_NESTED/packages/app/package.json ./packages/app/package.js
 COPY $EXTERNAL_SOURCE_NESTED/packages/backend/package.json ./packages/backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/scalprum-backend/package.json ./plugins/scalprum-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/dynamic-plugins-info-backend/package.json ./plugins/dynamic-plugins-info-backend/package.json
+COPY $EXTERNAL_SOURCE_NESTED/plugins/auth-backend-module-oidc-provider/package.json ./plugins/auth-backend-module-oidc-provider/package.json
 
 # Downstream only - debugging
 # COPY $REMOTE_SOURCES/ ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,7 @@ COPY $EXTERNAL_SOURCE_NESTED/packages/app/package.json ./packages/app/package.js
 COPY $EXTERNAL_SOURCE_NESTED/packages/backend/package.json ./packages/backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/scalprum-backend/package.json ./plugins/scalprum-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/dynamic-plugins-info-backend/package.json ./plugins/dynamic-plugins-info-backend/package.json
+COPY $EXTERNAL_SOURCE_NESTED/plugins/auth-backend-module-oidc-provider/package.json ./plugins/auth-backend-module-oidc-provider/package.json
 
 RUN $YARN install --frozen-lockfile --network-timeout 600000
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,6 +51,7 @@
     "@janus-idp/backstage-plugin-rbac-node": "1.0.3",
     "@manypkg/get-packages": "2.2.0",
     "app": "*",
+    "@internal/plugin-auth-backend-module-oidc-provider": "0.1.4-next.1",
     "better-sqlite3": "9.3.0",
     "express": "4.18.2",
     "express-prom-bundle": "6.6.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,7 +51,7 @@
     "@janus-idp/backstage-plugin-rbac-node": "1.0.3",
     "@manypkg/get-packages": "2.2.0",
     "app": "*",
-    "@internal/plugin-auth-backend-module-oidc-provider": "0.1.4-next.1",
+    "@internal/plugin-auth-backend-module-oidc-provider": "*",
     "better-sqlite3": "9.3.0",
     "express": "4.18.2",
     "express-prom-bundle": "6.6.0",

--- a/plugins/auth-backend-module-oidc-provider/.eslintrc.js
+++ b/plugins/auth-backend-module-oidc-provider/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/auth-backend-module-oidc-provider/README.md
+++ b/plugins/auth-backend-module-oidc-provider/README.md
@@ -1,0 +1,10 @@
+# Auth Module: Oidc Provider
+
+**This is a forked version of the Upstream Backstage Auth Backend Module OIDC Provider**
+
+This module provides an Oidc auth provider implementation for `@backstage/plugin-auth-backend`.
+
+## Links
+
+- [Repository](https://oidc.com/backstage/backstage/tree/master/plugins/auth-backend-module-oidc-provider)
+- [Backstage Project Homepage](https://backstage.io)

--- a/plugins/auth-backend-module-oidc-provider/config.d.ts
+++ b/plugins/auth-backend-module-oidc-provider/config.d.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  auth?: {
+    providers?: {
+      /** @visibility frontend */
+      oidc?: {
+        [authEnv: string]: {
+          clientId: string;
+          /**
+           * @visibility secret
+           */
+          clientSecret: string;
+          metadataUrl: string;
+          callbackUrl?: string;
+          tokenEndpointAuthMethod?: string;
+          tokenSignedResponseAlg?: string;
+          scope?: string;
+          prompt?: string;
+        };
+      };
+    };
+  };
+}

--- a/plugins/auth-backend-module-oidc-provider/dev/index.ts
+++ b/plugins/auth-backend-module-oidc-provider/dev/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('../src'));
+
+backend.start();

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@internal/plugin-auth-backend-module-oidc-provider",
+  "description": "The oidc-provider backend module for the auth plugin.",
+  "version": "0.1.4-next.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend-module-oidc-provider"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "0.21.0",
+    "@backstage/backend-plugin-api": "0.6.10",
+    "@backstage/plugin-auth-backend": "0.21.0",
+    "@backstage/plugin-auth-node": "0.4.5",
+    "express": "4.18.2",
+    "openid-client": "5.5.0",
+    "passport": "0.7.0"
+  },
+  "devDependencies": {
+    "@backstage/backend-defaults": "0.2.10",
+    "@backstage/backend-test-utils": "0.3.0",
+    "@backstage/cli": "0.25.2",
+    "@backstage/config": "1.1.1",
+    "cookie-parser": "1.4.6",
+    "express-promise-router": "4.1.1",
+    "express-session": "1.17.3",
+    "jose": "5.0.0",
+    "msw": "1.3.1",
+    "supertest": "6.3.3"
+  },
+  "configSchema": "config.d.ts",
+  "files": [
+    "dist",
+    "config.d.ts"
+  ]
+}

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internal/plugin-auth-backend-module-oidc-provider",
   "description": "The oidc-provider backend module for the auth plugin.",
-  "version": "0.1.4-next.1",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  OAuthAuthenticatorAuthenticateInput,
+  OAuthAuthenticatorRefreshInput,
+  OAuthAuthenticatorStartInput,
+  OAuthState,
+  decodeOAuthState,
+  encodeOAuthState,
+} from '@backstage/plugin-auth-node';
+import { oidcAuthenticator } from './authenticator';
+import { setupServer } from 'msw/node';
+import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
+import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { rest } from 'msw';
+import express from 'express';
+
+describe('oidcAuthenticator', () => {
+  let implementation: any;
+  let oauthState: OAuthState;
+  let idToken: string;
+  let publicKey: JWK;
+
+  const mswServer = setupServer();
+  setupRequestMockHandlers(mswServer);
+
+  const issuerMetadata = {
+    issuer: 'https://oidc.test',
+    authorization_endpoint: 'https://oidc.test/oauth2/authorize',
+    token_endpoint: 'https://oidc.test/oauth2/token',
+    revocation_endpoint: 'https://oidc.test/oauth2/revoke_token',
+    userinfo_endpoint: 'https://oidc.test/idp/userinfo.openid',
+    introspection_endpoint: 'https://oidc.test/introspect.oauth2',
+    jwks_uri: 'https://oidc.test/jwks.json',
+    scopes_supported: [
+      'openid',
+      'offline_access',
+      'oidc:request-audience',
+      'username',
+      'groups',
+    ],
+    claims_supported: ['email', 'username', 'groups', 'additionalClaims'],
+    response_types_supported: ['code'],
+    id_token_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
+    token_endpoint_auth_signing_alg_values_supported: [
+      'RS256',
+      'RS512',
+      'HS256',
+    ],
+    request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
+  };
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair('RS256');
+    const privateKey = await exportJWK(keyPair.privateKey);
+    publicKey = await exportJWK(keyPair.publicKey);
+    publicKey.alg = privateKey.alg = 'RS256';
+
+    idToken = await new SignJWT({
+      sub: 'test',
+      iss: 'https://oidc.test',
+      iat: Date.now(),
+      aud: 'clientId',
+      exp: Date.now() + 10000,
+    })
+      .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
+      .sign(keyPair.privateKey);
+  });
+
+  beforeEach(() => {
+    mswServer.use(
+      rest.get(
+        'https://oidc.test/.well-known/openid-configuration',
+        (_req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(issuerMetadata),
+          ),
+      ),
+      rest.get('https://oidc.test/jwks.json', async (_req, res, ctx) =>
+        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      ),
+      rest.post('https://oidc.test/oauth2/token', async (req, res, ctx) => {
+        return res(
+          req.headers.get('Authorization')
+            ? ctx.json({
+                access_token: 'accessToken',
+                id_token: idToken,
+                refresh_token: 'refreshToken',
+                scope: 'testScope',
+                expires_in: 3600,
+              })
+            : ctx.status(401),
+        );
+      }),
+      rest.get(
+        'https://oidc.test/idp/userinfo.openid',
+        async (_req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json({
+              sub: 'test',
+              name: 'Alice Adams',
+              given_name: 'Alice',
+              family_name: 'Adams',
+              email: 'alice@test.com',
+              picture: 'http://testPictureUrl/photo.jpg',
+            }),
+          ),
+      ),
+    );
+
+    implementation = oidcAuthenticator.initialize({
+      callbackUrl: 'https://backstage.test/callback',
+      config: new ConfigReader({
+        metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+      }),
+    });
+
+    oauthState = {
+      nonce: 'nonce',
+      env: 'env',
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('#start', () => {
+    let fakeSession: Record<string, any>;
+    let startRequest: OAuthAuthenticatorStartInput;
+
+    beforeEach(() => {
+      fakeSession = {};
+      startRequest = {
+        state: encodeOAuthState(oauthState),
+        req: {
+          method: 'GET',
+          url: 'test',
+          session: fakeSession,
+        },
+      } as unknown as OAuthAuthenticatorStartInput;
+    });
+
+    it('redirects to authorization endpoint returned from OIDC metadata endpoint', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const url = new URL(startResponse.url);
+
+      expect(url.protocol).toBe('https:');
+      expect(url.hostname).toBe('oidc.test');
+      expect(url.pathname).toBe('/oauth2/authorize');
+    });
+
+    it('initiates authorization code grant', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+
+      expect(searchParams.get('response_type')).toBe('code');
+    });
+
+    it('passes client ID from config', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+
+      expect(searchParams.get('client_id')).toBe('clientId');
+    });
+
+    it('passes callback URL from config', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+
+      expect(searchParams.get('redirect_uri')).toBe(
+        'https://backstage.test/callback',
+      );
+    });
+
+    it('generates PKCE challenge', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+
+      expect(searchParams.get('code_challenge_method')).toBe('S256');
+      expect(searchParams.get('code_challenge')).not.toBeNull();
+    });
+
+    it('stores PKCE verifier in session', async () => {
+      await oidcAuthenticator.start(startRequest, implementation);
+      expect(fakeSession['oidc:oidc.test'].code_verifier).toBeDefined();
+    });
+
+    it('requests default scopes if none are provided in config', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+      const scopes = searchParams.get('scope')?.split(' ') ?? [];
+
+      expect(scopes).toEqual(
+        expect.arrayContaining(['openid', 'profile', 'email']),
+      );
+    });
+
+    it('encodes OAuth state in query param', async () => {
+      const startResponse = await oidcAuthenticator.start(
+        startRequest,
+        implementation,
+      );
+      const { searchParams } = new URL(startResponse.url);
+      const stateParam = searchParams.get('state');
+      const decodedState = decodeOAuthState(stateParam!);
+
+      expect(decodedState).toMatchObject(oauthState);
+    });
+
+    it('fails when request has no session', async () => {
+      return expect(
+        oidcAuthenticator.start(
+          {
+            state: encodeOAuthState(oauthState),
+            req: {
+              method: 'GET',
+              url: 'test',
+            },
+          } as unknown as OAuthAuthenticatorStartInput,
+          implementation,
+        ),
+      ).rejects.toThrow('authentication requires session support');
+    });
+  });
+
+  describe('#authenticate', () => {
+    let handlerRequest: OAuthAuthenticatorAuthenticateInput;
+
+    beforeEach(() => {
+      handlerRequest = {
+        req: {
+          method: 'GET',
+          url: `https://test?code=authorization_code&state=${encodeOAuthState(
+            oauthState,
+          )}`,
+          session: {
+            'oidc:oidc.test': {
+              state: encodeOAuthState(oauthState),
+            },
+          },
+        } as unknown as express.Request,
+      };
+    });
+
+    it('exchanges authorization code for access token', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+      const accessToken = authenticatorResult.session.accessToken;
+
+      expect(accessToken).toEqual('accessToken');
+    });
+
+    it('exchanges authorization code for refresh token', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+      const refreshToken = authenticatorResult.session.refreshToken;
+
+      expect(refreshToken).toEqual('refreshToken');
+    });
+
+    it('returns granted scope', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+      const responseScope = authenticatorResult.session.scope;
+
+      expect(responseScope).toEqual('testScope');
+    });
+
+    it('returns a default session.tokentype field', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+      const tokenType = authenticatorResult.session.tokenType;
+
+      expect(tokenType).toEqual('bearer');
+    });
+
+    it('returns picture and email', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+
+      expect(authenticatorResult).toMatchObject({
+        fullProfile: {
+          userinfo: {
+            email: 'alice@test.com',
+            picture: 'http://testPictureUrl/photo.jpg',
+            name: 'Alice Adams',
+          },
+        },
+      });
+    });
+
+    it('returns idToken', async () => {
+      const authenticatorResult = await oidcAuthenticator.authenticate(
+        handlerRequest,
+        implementation,
+      );
+
+      expect(authenticatorResult).toMatchObject({
+        session: {
+          idToken,
+        },
+      });
+      expect(
+        Math.abs(authenticatorResult.session.expiresInSeconds! - 3600),
+      ).toBeLessThan(5);
+    });
+
+    it('fails without authorization code', async () => {
+      handlerRequest.req.url = 'https://test.com';
+      return expect(
+        oidcAuthenticator.authenticate(handlerRequest, implementation),
+      ).rejects.toThrow('Unexpected redirect');
+    });
+
+    it('fails without oauth state', async () => {
+      return expect(
+        oidcAuthenticator.authenticate(
+          {
+            req: {
+              method: 'GET',
+              url: `https://test?code=authorization_code}`,
+              session: {
+                ['oidc:pinniped.test']: {
+                  state: { handle: 'sessionid', code_verifier: 'foo' },
+                },
+              },
+            } as unknown as express.Request,
+          },
+          implementation,
+        ),
+      ).rejects.toThrow(
+        'Authentication failed, did not find expected authorization request details in session, req.session["oidc:oidc.test"] is undefined',
+      );
+    });
+
+    it('fails when request has no session', async () => {
+      return expect(
+        oidcAuthenticator.authenticate(
+          {
+            req: {
+              method: 'GET',
+              url: 'https://test.com',
+            } as unknown as express.Request,
+          },
+          implementation,
+        ),
+      ).rejects.toThrow('authentication requires session support');
+    });
+  });
+
+  describe('#refresh', () => {
+    let refreshRequest: OAuthAuthenticatorRefreshInput;
+
+    beforeEach(() => {
+      refreshRequest = {
+        scope: '',
+        refreshToken: 'otherRefreshToken',
+        req: {} as express.Request,
+      };
+    });
+
+    it('gets new refresh token', async () => {
+      const refreshResponse = await oidcAuthenticator.refresh(
+        refreshRequest,
+        implementation,
+      );
+
+      expect(refreshResponse.session.refreshToken).toBe('refreshToken');
+    });
+
+    it('gets access token', async () => {
+      const refreshResponse = await oidcAuthenticator.refresh(
+        refreshRequest,
+        implementation,
+      );
+
+      expect(refreshResponse.session.accessToken).toBe('accessToken');
+    });
+
+    it('gets id token', async () => {
+      const refreshResponse = await oidcAuthenticator.refresh(
+        refreshRequest,
+        implementation,
+      );
+
+      expect(refreshResponse.session.idToken).toBe(idToken);
+    });
+  });
+});

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -119,7 +119,7 @@ describe('oidcAuthenticator', () => {
               given_name: 'Alice',
               family_name: 'Adams',
               email: 'alice@test.com',
-              picture: 'http://testPictureUrl/photo.jpg',
+              picture: 'http://testPictureUrl/photo.jpg', // NOSONAR
             }),
           ),
       ),
@@ -330,7 +330,7 @@ describe('oidcAuthenticator', () => {
         fullProfile: {
           userinfo: {
             email: 'alice@test.com',
-            picture: 'http://testPictureUrl/photo.jpg',
+            picture: 'http://testPictureUrl/photo.jpg', // NOSONAR
             name: 'Alice Adams',
           },
         },

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  custom,
+  CustomHttpOptionsProvider,
   Issuer,
   ClientAuthMethod,
   TokenSet,
@@ -29,6 +31,14 @@ import {
   PassportOAuthAuthenticatorHelper,
   PassportOAuthPrivateInfo,
 } from '@backstage/plugin-auth-node';
+
+const HTTP_OPTION_TIMEOUT = 10000;
+const httpOptionsProvider: CustomHttpOptionsProvider = (_url, options) => {
+  return {
+    ...options,
+    timeout: HTTP_OPTION_TIMEOUT,
+  };
+};
 
 /**
  * authentication result for the OIDC which includes the token set and user
@@ -66,7 +76,11 @@ export const oidcAuthenticator = createOAuthAuthenticator({
     const initializedScope = config.getOptionalString('scope');
     const initializedPrompt = config.getOptionalString('prompt');
 
+    Issuer[custom.http_options] = httpOptionsProvider;
     const promise = Issuer.discover(metadataUrl).then(issuer => {
+      issuer[custom.http_options] = httpOptionsProvider;
+      issuer.Client[custom.http_options] = httpOptionsProvider;
+
       const client = new issuer.Client({
         access_type: 'offline', // this option must be passed to provider to receive a refresh token
         client_id: clientId,
@@ -78,6 +92,7 @@ export const oidcAuthenticator = createOAuthAuthenticator({
         id_token_signed_response_alg: tokenSignedResponseAlg || 'RS256',
         scope: initializedScope || '',
       });
+      client[custom.http_options] = httpOptionsProvider;
 
       const strategy = new OidcStrategy(
         {

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Issuer,
+  ClientAuthMethod,
+  TokenSet,
+  UserinfoResponse,
+  Strategy as OidcStrategy,
+} from 'openid-client';
+import {
+  createOAuthAuthenticator,
+  OAuthAuthenticatorResult,
+  PassportDoneCallback,
+  PassportHelpers,
+  PassportOAuthAuthenticatorHelper,
+  PassportOAuthPrivateInfo,
+} from '@backstage/plugin-auth-node';
+
+/**
+ * authentication result for the OIDC which includes the token set and user
+ * profile response
+ * @public
+ */
+export type OidcAuthResult = {
+  tokenset: TokenSet;
+  userinfo: UserinfoResponse;
+};
+
+/** @public */
+export const oidcAuthenticator = createOAuthAuthenticator({
+  shouldPersistScopes: true,
+  defaultProfileTransform: async (
+    input: OAuthAuthenticatorResult<OidcAuthResult>,
+  ) => ({
+    profile: {
+      email: input.fullProfile.userinfo.email,
+      picture: input.fullProfile.userinfo.picture,
+      displayName: input.fullProfile.userinfo.name,
+    },
+  }),
+  initialize({ callbackUrl, config }) {
+    const clientId = config.getString('clientId');
+    const clientSecret = config.getString('clientSecret');
+    const metadataUrl = config.getString('metadataUrl');
+    const customCallbackUrl = config.getOptionalString('callbackUrl');
+    const tokenEndpointAuthMethod = config.getOptionalString(
+      'tokenEndpointAuthMethod',
+    ) as ClientAuthMethod;
+    const tokenSignedResponseAlg = config.getOptionalString(
+      'tokenSignedResponseAlg',
+    );
+    const initializedScope = config.getOptionalString('scope');
+    const initializedPrompt = config.getOptionalString('prompt');
+
+    const promise = Issuer.discover(metadataUrl).then(issuer => {
+      const client = new issuer.Client({
+        access_type: 'offline', // this option must be passed to provider to receive a refresh token
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uris: [customCallbackUrl || callbackUrl],
+        response_types: ['code'],
+        token_endpoint_auth_method:
+          tokenEndpointAuthMethod || 'client_secret_basic',
+        id_token_signed_response_alg: tokenSignedResponseAlg || 'RS256',
+        scope: initializedScope || '',
+      });
+
+      const strategy = new OidcStrategy(
+        {
+          client,
+          passReqToCallback: false,
+        },
+        (
+          tokenset: TokenSet,
+          userinfo: UserinfoResponse,
+          done: PassportDoneCallback<OidcAuthResult, PassportOAuthPrivateInfo>,
+        ) => {
+          if (typeof done !== 'function') {
+            throw new Error(
+              'OIDC IdP must provide a userinfo_endpoint in the metadata response',
+            );
+          }
+
+          done(
+            undefined,
+            { tokenset, userinfo },
+            { refreshToken: tokenset.refresh_token },
+          );
+        },
+      );
+
+      const helper = PassportOAuthAuthenticatorHelper.from(strategy);
+      return { helper, client, strategy };
+    });
+
+    return { initializedScope, initializedPrompt, promise };
+  },
+
+  async start(input, ctx) {
+    const { initializedScope, initializedPrompt, promise } = ctx;
+    const { helper, strategy } = await promise;
+    const options: Record<string, string> = {
+      scope: input.scope || initializedScope || 'openid profile email',
+      state: input.state,
+    };
+    const prompt = initializedPrompt || 'none';
+    if (prompt !== 'auto') {
+      options.prompt = prompt;
+    }
+
+    return new Promise((resolve, reject) => {
+      strategy.error = reject;
+
+      return helper
+        .start(input, {
+          ...options,
+        })
+        .then(resolve);
+    });
+  },
+
+  async authenticate(
+    input,
+    ctx,
+  ): Promise<OAuthAuthenticatorResult<OidcAuthResult>> {
+    const { strategy } = await ctx.promise;
+    const { result, privateInfo } =
+      await PassportHelpers.executeFrameHandlerStrategy<
+        OidcAuthResult,
+        PassportOAuthPrivateInfo
+      >(input.req, strategy);
+
+    return {
+      fullProfile: result,
+      session: {
+        accessToken: result.tokenset.access_token!,
+        tokenType: result.tokenset.token_type ?? 'bearer',
+        scope: result.tokenset.scope!,
+        expiresInSeconds: result.tokenset.expires_in,
+        idToken: result.tokenset.id_token,
+        refreshToken: privateInfo.refreshToken,
+      },
+    };
+  },
+
+  async refresh(input, ctx) {
+    const { client } = await ctx.promise;
+    const tokenset = await client.refresh(input.refreshToken);
+    if (!tokenset.access_token) {
+      throw new Error('Refresh failed');
+    }
+    const userinfo = await client.userinfo(tokenset.access_token);
+
+    return new Promise((resolve, reject) => {
+      if (!tokenset.access_token) {
+        reject(new Error('Refresh Failed'));
+      }
+      resolve({
+        fullProfile: { userinfo, tokenset },
+        session: {
+          accessToken: tokenset.access_token!,
+          tokenType: tokenset.token_type ?? 'bearer',
+          scope: tokenset.scope!,
+          expiresInSeconds: tokenset.expires_in,
+          idToken: tokenset.id_token,
+          refreshToken: tokenset.refresh_token,
+        },
+      });
+    });
+  },
+
+  async logout(input, ctx) {
+    const { client } = await ctx.promise;
+
+    if (input.refreshToken) {
+      await client.revoke(input.refreshToken);
+    }
+  },
+});

--- a/plugins/auth-backend-module-oidc-provider/src/index.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The oidc-provider backend module for the auth plugin.
+ *
+ * @packageDocumentation
+ */
+
+export { oidcAuthenticator } from './authenticator';
+export type { OidcAuthResult } from './authenticator';
+export { authModuleOidcProvider as default } from './module';
+export { oidcSignInResolvers } from './resolvers';

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import request from 'supertest';
+import { decodeOAuthState } from '@backstage/plugin-auth-node';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import {
+  mockServices,
+  setupRequestMockHandlers,
+  startTestBackend,
+} from '@backstage/backend-test-utils';
+import { Server } from 'http';
+import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
+import { authModuleOidcProvider } from './module';
+
+describe('authModuleOidcProvider', () => {
+  let backstageServer: Server;
+  let appUrl: string;
+  let idToken: string;
+  let publicKey: JWK;
+
+  const mswServer = setupServer();
+  setupRequestMockHandlers(mswServer);
+
+  const issuerMetadata = {
+    issuer: 'https://oidc.test',
+    authorization_endpoint: 'https://oidc.test/oauth2/authorize',
+    token_endpoint: 'https://oidc.test/oauth2/token',
+    revocation_endpoint: 'https://oidc.test/oauth2/revoke_token',
+    userinfo_endpoint: 'https://oidc.test/idp/userinfo.openid',
+    introspection_endpoint: 'https://oidc.test/as/introspect.oauth2',
+    jwks_uri: 'https://oidc.test/jwks.json',
+    scopes_supported: ['openid'],
+    claims_supported: ['email'],
+    response_types_supported: ['code'],
+    id_token_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
+    token_endpoint_auth_signing_alg_values_supported: [
+      'RS256',
+      'RS512',
+      'HS256',
+    ],
+    request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
+  };
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair('RS256');
+    const privateKey = await exportJWK(keyPair.privateKey);
+    publicKey = await exportJWK(keyPair.publicKey);
+    publicKey.alg = privateKey.alg = 'RS256';
+
+    idToken = await new SignJWT({
+      sub: 'test',
+      iss: 'https://oidc.test',
+      iat: Date.now(),
+      aud: 'clientId',
+      exp: Date.now() + 10000,
+    })
+      .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
+      .sign(keyPair.privateKey);
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mswServer.use(
+      rest.get(
+        'https://oidc.test/.well-known/openid-configuration',
+        (_req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json(issuerMetadata),
+          ),
+      ),
+      rest.get('https://oidc.test/oauth2/authorize', async (req, res, ctx) => {
+        const callbackUrl = new URL(req.url.searchParams.get('redirect_uri')!);
+        callbackUrl.searchParams.set('code', 'authorization_code');
+        callbackUrl.searchParams.set(
+          'state',
+          req.url.searchParams.get('state')!,
+        );
+        callbackUrl.searchParams.set('scope', 'test-scope');
+        return res(
+          ctx.status(302),
+          ctx.set('Location', callbackUrl.toString()),
+        );
+      }),
+      rest.get('https://oidc.test/jwks.json', async (_req, res, ctx) =>
+        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      ),
+      rest.post('https://oidc.test/oauth2/token', async (req, res, ctx) => {
+        return res(
+          req.headers.get('Authorization')
+            ? ctx.json({
+                access_token: 'accessToken',
+                id_token: idToken,
+                refresh_token: 'refreshToken',
+                scope: 'testScope',
+                token_type: '',
+                expires_in: 3600,
+              })
+            : ctx.status(401),
+        );
+      }),
+      rest.get(
+        'https://oidc.test/idp/userinfo.openid',
+        async (_req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json({
+              sub: 'test',
+              name: 'Alice Adams',
+              given_name: 'Alice',
+              family_name: 'Adams',
+              email: 'alice@test.com',
+              picture: 'http://testPictureUrl/photo.jpg',
+            }),
+          ),
+      ),
+    );
+
+    const backend = await startTestBackend({
+      features: [
+        authModuleOidcProvider,
+        import('@backstage/plugin-auth-backend'),
+        mockServices.rootConfig.factory({
+          data: {
+            app: { baseUrl: 'http://localhost' },
+            auth: {
+              session: { secret: 'test' },
+              providers: {
+                oidc: {
+                  development: {
+                    metadataUrl:
+                      'https://oidc.test/.well-known/openid-configuration',
+                    clientId: 'clientId',
+                    clientSecret: 'clientSecret',
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    backstageServer = backend.server;
+    const port = backend.server.port();
+    appUrl = `http://localhost:${port}`;
+    mswServer.use(rest.all(`http://*:${port}/*`, req => req.passthrough()));
+  });
+
+  afterEach(() => {
+    backstageServer.close();
+  });
+
+  it('should start', async () => {
+    const agent = request.agent(backstageServer);
+
+    const startResponse = await agent.get(
+      `/api/auth/oidc/start?env=development`,
+    );
+    expect(startResponse.status).toEqual(302);
+
+    const nonceCookie = agent.jar.getCookie('oidc-nonce', {
+      domain: 'localhost',
+      path: '/api/auth/oidc/handler',
+      script: false,
+      secure: false,
+    });
+    expect(nonceCookie).toBeDefined();
+
+    const startUrl = new URL(startResponse.get('location'));
+    expect(startUrl.origin).toBe('https://oidc.test');
+    expect(startUrl.pathname).toBe('/oauth2/authorize');
+    expect(Object.fromEntries(startUrl.searchParams)).toEqual({
+      response_type: 'code',
+      scope: 'openid profile email',
+      client_id: 'clientId',
+      redirect_uri: `${appUrl}/api/auth/oidc/handler/frame`,
+      state: expect.any(String),
+      prompt: 'none',
+      code_challenge: expect.any(String),
+      code_challenge_method: `S256`,
+    });
+
+    expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
+      env: 'development',
+      nonce: decodeURIComponent(nonceCookie.value),
+    });
+  });
+
+  it('#authenticate exchanges authorization code for a access_token', async () => {
+    const agent = request.agent('');
+    const startResponse = await agent.get(
+      `${appUrl}/api/auth/oidc/start?env=development`,
+    );
+    const authorizationResponse = await agent.get(
+      startResponse.header.location,
+    );
+    const handlerResponse = await agent.get(
+      authorizationResponse.header.location,
+    );
+
+    expect(handlerResponse.text).toContain(
+      encodeURIComponent(`"accessToken":"accessToken"`),
+    );
+  });
+});

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -127,7 +127,7 @@ describe('authModuleOidcProvider', () => {
               given_name: 'Alice',
               family_name: 'Adams',
               email: 'alice@test.com',
-              picture: 'http://testPictureUrl/photo.jpg',
+              picture: 'http://testPictureUrl/photo.jpg', // NOSONAR
             }),
           ),
       ),
@@ -200,7 +200,7 @@ describe('authModuleOidcProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 

--- a/plugins/auth-backend-module-oidc-provider/src/module.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import {
+  authProvidersExtensionPoint,
+  commonSignInResolvers,
+  createOAuthProviderFactory,
+} from '@backstage/plugin-auth-node';
+import { oidcAuthenticator } from './authenticator';
+import { oidcSignInResolvers } from './resolvers';
+
+/** @public */
+export const authModuleOidcProvider = createBackendModule({
+  pluginId: 'auth',
+  moduleId: 'oidc-provider',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        providers: authProvidersExtensionPoint,
+      },
+      async init({ providers }) {
+        providers.registerProvider({
+          providerId: 'oidc',
+          factory: createOAuthProviderFactory({
+            authenticator: oidcAuthenticator,
+            signInResolverFactories: {
+              ...oidcSignInResolvers,
+              ...commonSignInResolvers,
+            },
+          }),
+        });
+      },
+    });
+  },
+});

--- a/plugins/auth-backend-module-oidc-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/resolvers.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { commonSignInResolvers } from '@backstage/plugin-auth-node';
+
+/**
+ * Available sign-in resolvers for the Oidc auth provider.
+ *
+ * @public
+ */
+export namespace oidcSignInResolvers {
+  /**
+   * A oidc resolver that looks up the user using the local part of
+   * their email address as the entity name.
+   */
+  export const emailLocalPartMatchingUserEntityName =
+    commonSignInResolvers.emailLocalPartMatchingUserEntityName;
+
+  /**
+   * A oidc resolver that looks up the user using their email address
+   * as email of the entity.
+   */
+  export const emailMatchingUserEntityProfileEmail =
+    commonSignInResolvers.emailMatchingUserEntityProfileEmail;
+}

--- a/showcase-docs/auth.md
+++ b/showcase-docs/auth.md
@@ -1,0 +1,132 @@
+# Auth Providers within Backstage Showcase
+
+Currently we incorporate many of the Authentication providers available within Backstage. The Showcase supports the following providers:
+
+| Auth Provider        | Auth Provider ID  |
+| -------------------- | ----------------- |
+| Auth0                | `auth0`           |
+| Atlassian            | `atlassian`       |
+| Azure                | `microsoft`       |
+| Azure Easy Auth      | `azure-easyauth`  |
+| Bitbucket            | `bitbucket`       |
+| Bitbucket Server     | `bitbucketServer` |
+| Cloudflare Access    | `cfaccess`        |
+| GitHub               | `github`          |
+| GitLab               | `gitlab`          |
+| Google               | `google`          |
+| Google IAP           | `gcp-iap`         |
+| OIDC                 | `oidc`            |
+| Okta                 | `okta`            |
+| OAuth 2 Custom Proxy | `oauth2Proxy`     |
+| OneLogin             | `onelogin`        |
+| SAML                 | `saml`            |
+
+## Enabling Authentication in Showcase
+
+### GitHub
+
+- Add the GitHub Authentication provider details as outlined below.
+
+  ```yaml
+  auth:
+    environment: development
+    providers:
+      github:
+        development:
+          clientId: ${AUTH_GITHUB_CLIENT_ID}
+          clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+          ## uncomment if using GitHub Enterprise
+          # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
+          ## uncomment if using a custom callback url
+          # callbackUrl: ${AUTH_GITHUB_CALLBACK_URL}
+  ```
+
+For more information on setting up the GitHub auth provider, consult the [Backstage documentation](https://backstage.io/docs/auth/github/provider).
+
+### GitLab
+
+- Add the GitLab Authentication provider details as outlined below.
+
+  ```yaml
+  auth:
+    environment: development
+    providers:
+      gitlab:
+        development:
+          clientId: ${AUTH_GITLAB_CLIENT_ID}
+          clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
+          ## uncomment if using self-hosted GitLab
+          # audience: https://gitlab.company.com
+          ## uncomment if using a custom redirect URI
+          # callbackUrl: https://${BASE_URL}/api/auth/gitlab/handler/frame
+  ```
+
+For more information on setting up the GitLab auth provider, consult the [Backstage documentation](https://backstage.io/docs/auth/gitlab/provider).
+
+### OAuth2 Proxy
+
+The OAuth2 Proxy Authentication provider will require an OAuth2 Proxy server. You can consult the [official documentation](https://oauth2-proxy.github.io/oauth2-proxy/) for OAuth2 Proxy, as well as our available [blog post](https://janus-idp.io/blog/2023/01/17/enabling-keycloak-authentication-in-backstage) on the topic.
+
+- Add the OAuth2 Proxy Authentication provider details as outlined below.
+
+  ```yaml
+  auth:
+  environment: development
+  providers:
+    oauth2Proxy: {}
+  ```
+
+For more information on setting up the OAuth2 Proxy auth provider, consult the [Backstage documentation](https://backstage.io/docs/auth/oauth2-proxy/provider).
+
+### OIDC
+
+- Add the OIDC Authentication provider details as outlined below.
+
+  ```yaml
+  auth:
+    environment: development
+    # Providing an auth.session.secret will enable session support in the auth-backend
+    session:
+      secret: ${SESSION_SECRET}
+    providers:
+      oidc:
+        development:
+          metadataUrl: ${AUTH_OIDC_METADATA_URL}
+          clientId: ${AUTH_OIDC_CLIENT_ID}
+          clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
+          prompt: ${AUTH_OIDC_PROMPT} # recommended to use auto
+          ## uncomment for additional configuration options
+          # callbackUrl: ${AUTH_OIDC_CALLBACK_URL}
+          # tokenEndpointAuthMethod: ${AUTH_OIDC_TOKEN_ENDPOINT_METHOD}
+          # tokenSignedResponseAlg: ${AUTH_OIDC_SIGNED_RESPONSE_ALG}
+          # scope: ${AUTH_OIDC_SCOPE}
+  ```
+
+In an example using Keycloak for authentication with the OIDC provider, there are a few steps that need to be taken to get everything working:
+
+1. Create a realm named keycloak.
+2. Create the client backstage with Client authentication checked.
+3. Set the Valid redirect URIs to `<BACKSTAGE_URL>/api/auth/oidc/handler/frame`. If running Backstage Showcase locally, it would look something like this: `http://localhost:7007/api/auth/oidc/handler/frame`.
+4. Set the `metadataUrl` to the URL of your Keycloak instance and realm. It should look similar to this: `<KEYCLOAK_URL>/realms/keycloak`.
+5. Set the `clientId` to `backstage`.
+6. Obtain the client secret for the client backstage within Keycloak and set `clientSecret`.
+7. Set the `prompt` to `auto`.
+8. Finally, set `auth.session.secret` to `superSecretSecret`.
+
+For more information on setting up the OIDC auth provider, consult the [Backstage documentation](https://backstage.io/docs/auth/oidc#the-configuration).
+
+### Sign In Page configuration value
+
+After selecting the authentication provider you wish to use with your Backstage Showcase instance, ensure to add the `signInPage` configuration value to ensure that the frontend displays the appropriate authentication provider.
+
+- Add the corresponding Authentication provider key as the value to `signInPage` in your `app-config`. Where `provider-id` matches the chosen provider from the table above.
+
+  ```yaml
+  signInPage: <provider-id>
+  ```
+
+### Disabling the guest login
+
+We also offer an option to disable the Guest Login provider that disable the ability for guests to login to your Backstage Showcase instance.
+
+- To disable the guest login set `auth.environment` to `production`.

--- a/showcase-docs/getting-started.md
+++ b/showcase-docs/getting-started.md
@@ -123,34 +123,7 @@ The easiest and fastest method for getting started: Backstage Showcase app, runn
 
    - Enabling Authentication in Showcase
 
-     - To enable authentication in the Showcase, add the [respective config](https://backstage.io/docs/auth/) in your `app-config`. The Showcase supports the following providers:
-
-       - Auth0 - `auth0`
-       - Atlassian - `atlassian`
-       - Azure - `microsoft`
-       - Azure Easy Auth - `azure-easyauth`
-       - Bitbucket - `bitbucket`
-       - Bitbucket Server - `bitbucketServer`
-       - Cloudflare Access - `cfaccess`
-       - GitHub - `github`
-       - GitLab - `gitlab`
-       - Google - `google`
-       - Google IAP - `gcp-iap`
-       - OIDC - `oidc`
-       - Okta - `okta`
-       - OAuth 2 Custom Proxy - `oauth2Proxy`
-       - OneLogin - `onelogin`
-       - SAML - `saml`
-
-     - Add the corresponding authentication provider key as the value to `signInPage` in your `app-config`.
-
-       e.g.
-
-       ```yaml
-       signInPage: oidc
-       ```
-
-     - To disable the guest login set `auth.environment` to `production`.
+     - Refer to the [authentication documentation](./auth.md) for the available auth providers and the steps to configure them.
 
    - Setup the RBAC plugin
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,6 +2156,67 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
+"@backstage/backend-common@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.21.0.tgz#72595fa7367727fbfff07223a8ed37d2c07efaa4"
+  integrity sha512-TfUNUtdWGD+opArGM4xCPGGJMW2HU557AA7nzMZYF+UZWBn0Pyjo9DVED/+A4VqMo5dGwLTB7g2odROfkNxZMA==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-app-api" "^0.5.11"
+    "@backstage/backend-dev-utils" "^0.1.4"
+    "@backstage/backend-plugin-api" "^0.6.10"
+    "@backstage/cli-common" "^0.1.13"
+    "@backstage/config" "^1.1.1"
+    "@backstage/config-loader" "^1.6.2"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/integration" "^1.9.0"
+    "@backstage/integration-aws-node" "^0.1.9"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/storage" "^7.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@kubernetes/client-node" "0.20.0"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@types/cors" "^2.8.6"
+    "@types/dockerode" "^3.3.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    "@types/webpack-env" "^1.15.2"
+    archiver "^6.0.0"
+    base64-stream "^1.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cors "^2.8.5"
+    dockerode "^4.0.0"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^14.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^4.6.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^5.0.0"
+    mysql2 "^2.2.5"
+    node-fetch "^2.6.7"
+    p-limit "^3.1.0"
+    pg "^8.11.3"
+    raw-body "^2.4.1"
+    tar "^6.1.12"
+    uuid "^8.3.2"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^2.10.0"
+    yn "^4.0.0"
+
 "@backstage/backend-common@0.21.3", "@backstage/backend-common@^0.21.0", "@backstage/backend-common@^0.21.2", "@backstage/backend-common@^0.21.3":
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.21.3.tgz#67d757d1ff81a79121bdbe80b3032542f5ff571f"
@@ -2277,6 +2338,14 @@
     winston-transport "^4.5.0"
     yauzl "^2.10.0"
     yn "^4.0.0"
+
+"@backstage/backend-defaults@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-defaults/-/backend-defaults-0.2.10.tgz#a5d752f42acdff11f86c7fc007e479062f4519fb"
+  integrity sha512-3bR6ZgRwoIz0IPOljZJGo2Q5m2TEugRoSi+Zlm+hPpWDR1+35spt2Zixf1t62ybmmcXkdh0VCq/S6Xtha+hMrg==
+  dependencies:
+    "@backstage/backend-app-api" "^0.5.11"
+    "@backstage/backend-common" "^0.21.0"
 
 "@backstage/backend-defaults@0.2.13":
   version "0.2.13"
@@ -2420,6 +2489,29 @@
     uuid "^8.0.0"
     winston "^3.2.1"
     zod "^3.22.4"
+
+"@backstage/backend-test-utils@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-test-utils/-/backend-test-utils-0.3.0.tgz#f4e9027e5e2f573ae5b45772ecff2a3194a97811"
+  integrity sha512-k+eAtv4Zs3Zw3cKUT/Z/So3qk3DrZ91R+cuIWwt4oy2nOqXzhEp4pJLpy9BR7/ekXrD0CmuoKrEfvE+4pqwDgQ==
+  dependencies:
+    "@backstage/backend-app-api" "^0.5.11"
+    "@backstage/backend-common" "^0.21.0"
+    "@backstage/backend-plugin-api" "^0.6.10"
+    "@backstage/config" "^1.1.1"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/plugin-auth-node" "^0.4.4"
+    "@backstage/types" "^1.1.1"
+    better-sqlite3 "^9.0.0"
+    express "^4.17.1"
+    fs-extra "^11.0.0"
+    knex "^3.0.0"
+    msw "^1.0.0"
+    mysql2 "^2.2.5"
+    pg "^8.11.3"
+    testcontainers "^8.1.2"
+    textextensions "^5.16.0"
+    uuid "^8.0.0"
 
 "@backstage/backend-test-utils@^0.3.3":
   version "0.3.3"
@@ -2894,7 +2986,7 @@
     express "^4.17.1"
     fs-extra "^11.2.0"
 
-"@backstage/plugin-auth-backend-module-atlassian-provider@^0.1.5":
+"@backstage/plugin-auth-backend-module-atlassian-provider@^0.1.2", "@backstage/plugin-auth-backend-module-atlassian-provider@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-atlassian-provider/-/plugin-auth-backend-module-atlassian-provider-0.1.5.tgz#7b4f60b421ba3d49b9b2b9c496a5cf424317acdb"
   integrity sha512-o7MEBqTS8N8cqE2hvrbZvV/DsbunUOQL0hu1/i1JCaJjVV91BNmA3xVnf3810aF0+Zvi7OBKnGG17YZD/+Ozpw==
@@ -2905,7 +2997,7 @@
     passport "^0.7.0"
     passport-atlassian-oauth2 "^2.1.0"
 
-"@backstage/plugin-auth-backend-module-aws-alb-provider@^0.1.4":
+"@backstage/plugin-auth-backend-module-aws-alb-provider@^0.1.0", "@backstage/plugin-auth-backend-module-aws-alb-provider@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-aws-alb-provider/-/plugin-auth-backend-module-aws-alb-provider-0.1.4.tgz#c7171daed03c000b74c6150d03d5e3a9e59a68af"
   integrity sha512-o9WrNo/QDqVOZgoyCww315snMehq+Q2ZiLO1SWhnbHZjQxP+uWiM+tW2BQee6UIkUt0HxaYwRur/+veNHDuc9A==
@@ -2919,7 +3011,7 @@
     node-cache "^5.1.2"
     node-fetch "^2.6.7"
 
-"@backstage/plugin-auth-backend-module-gcp-iap-provider@^0.2.8":
+"@backstage/plugin-auth-backend-module-gcp-iap-provider@^0.2.4", "@backstage/plugin-auth-backend-module-gcp-iap-provider@^0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-gcp-iap-provider/-/plugin-auth-backend-module-gcp-iap-provider-0.2.8.tgz#d112d288e46da40e166e4700249b200af84db9b8"
   integrity sha512-hXVBoAxFR30T3Mxo8oecDScQuQsf5D87L1tsx+IRDNio2fZXpmmi6fPFbSkOymPHoJVRQUUe1t0jk2iwn40rIg==
@@ -2930,7 +3022,7 @@
     "@backstage/types" "^1.1.1"
     google-auth-library "^8.0.0"
 
-"@backstage/plugin-auth-backend-module-github-provider@^0.1.10":
+"@backstage/plugin-auth-backend-module-github-provider@^0.1.10", "@backstage/plugin-auth-backend-module-github-provider@^0.1.7":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-github-provider/-/plugin-auth-backend-module-github-provider-0.1.10.tgz#da6c734b0aa414b33217385d368212b3aa3b6e27"
   integrity sha512-oOftUR4mK+9R3os/nRa0j++PdxgOaYCHOjh+HeRqLOBbAgxizLPHxgBufkdeh1P7Rj2y1nE2Kpba+Xj7+PL1pg==
@@ -2939,7 +3031,7 @@
     "@backstage/plugin-auth-node" "^0.4.8"
     passport-github2 "^0.1.12"
 
-"@backstage/plugin-auth-backend-module-gitlab-provider@^0.1.10":
+"@backstage/plugin-auth-backend-module-gitlab-provider@^0.1.10", "@backstage/plugin-auth-backend-module-gitlab-provider@^0.1.7":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-gitlab-provider/-/plugin-auth-backend-module-gitlab-provider-0.1.10.tgz#31a0f2f150dba2dc887e981b9f689be27c255467"
   integrity sha512-ku2Nk/l80IutDtl2inbjQa/3gxObxaFroC6dzJC2Pdbq/Av+u+dtC3ayH9bDelD4WelVnK3kflktU3KaXdVEWg==
@@ -2950,7 +3042,7 @@
     passport "^0.7.0"
     passport-gitlab2 "^5.0.0"
 
-"@backstage/plugin-auth-backend-module-google-provider@^0.1.10":
+"@backstage/plugin-auth-backend-module-google-provider@^0.1.10", "@backstage/plugin-auth-backend-module-google-provider@^0.1.7":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-google-provider/-/plugin-auth-backend-module-google-provider-0.1.10.tgz#5a1404bc9b251c89077b095ac0f54ffa122a2885"
   integrity sha512-1CZue7y5F6O36Aeqgw2SHncW6NVtnOpjw9KDsMh/uR2CJtgLess+GMd8poPkQYxnjwk93TnRQdZPPDvVOq8KFA==
@@ -2960,7 +3052,7 @@
     google-auth-library "^8.0.0"
     passport-google-oauth20 "^2.0.0"
 
-"@backstage/plugin-auth-backend-module-microsoft-provider@^0.1.8":
+"@backstage/plugin-auth-backend-module-microsoft-provider@^0.1.5", "@backstage/plugin-auth-backend-module-microsoft-provider@^0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-microsoft-provider/-/plugin-auth-backend-module-microsoft-provider-0.1.8.tgz#8a89fdd5722b05ff238fa4466eda2712b022c303"
   integrity sha512-qwX3yNe+n2SRs3c6KUoB8M0VOoXHCHPjnUZH31/8DvJRZI2gegbjzXaZkyBsaGnuerFaEQ6b9BfoWFt2+zbm3w==
@@ -2974,7 +3066,7 @@
     passport "^0.7.0"
     passport-microsoft "^1.0.0"
 
-"@backstage/plugin-auth-backend-module-oauth2-provider@^0.1.10":
+"@backstage/plugin-auth-backend-module-oauth2-provider@^0.1.10", "@backstage/plugin-auth-backend-module-oauth2-provider@^0.1.7":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-oauth2-provider/-/plugin-auth-backend-module-oauth2-provider-0.1.10.tgz#d6ac1ed11cf70cff72ebba00dccb23e38bcc9bcb"
   integrity sha512-cG5NLT48ZRZhivBWiK26cAZximMZamJ4rXD8R7cNOQLTh/vrVEPQhrpLyKC0QQRO0XzpkF868RL6OjI8gu8+Lw==
@@ -2984,7 +3076,7 @@
     passport "^0.7.0"
     passport-oauth2 "^1.6.1"
 
-"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@^0.1.6":
+"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@^0.1.2", "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-oauth2-proxy-provider/-/plugin-auth-backend-module-oauth2-proxy-provider-0.1.6.tgz#6fbac89360b281c48bac4ff3b339f83c2319d7b2"
   integrity sha512-H3GfMzfxmkiIh6Jp3LhSFxr9vtCGXwLdr9mlPR0qt1X+I/a7ZPrn0GIUUmC+f82niYkt/+sn+2F7u68EGwA2JQ==
@@ -2994,7 +3086,7 @@
     "@backstage/plugin-auth-node" "^0.4.8"
     jose "^4.6.0"
 
-"@backstage/plugin-auth-backend-module-oidc-provider@^0.1.3":
+"@backstage/plugin-auth-backend-module-oidc-provider@^0.1.0", "@backstage/plugin-auth-backend-module-oidc-provider@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-oidc-provider/-/plugin-auth-backend-module-oidc-provider-0.1.3.tgz#20c7406b46ed17f4685d3535a5011ceeaafa312a"
   integrity sha512-AkpAYUKGxdEb6SVXjz6RqX00UAGhXXQznPAfgwGeeD6LD6e+qcKejfwnuUksaGJocHmOVl61v1yaAzq585fdMw==
@@ -3007,6 +3099,17 @@
     openid-client "^5.5.0"
     passport "^0.7.0"
 
+"@backstage/plugin-auth-backend-module-okta-provider@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-okta-provider/-/plugin-auth-backend-module-okta-provider-0.0.3.tgz#ba10dacf488f93a644f8238b6eed8341e7343995"
+  integrity sha512-jUYIxv96J2asO09xhiOJYMf5KNjSgKpaH/h1N/TL3xZCa4fVbK03zXhmIFGxr6yQfIZON672mhifpHlU0Z9nrw==
+  dependencies:
+    "@backstage/backend-plugin-api" "^0.6.10"
+    "@backstage/plugin-auth-node" "^0.4.4"
+    "@davidzemon/passport-okta-oauth" "^0.0.5"
+    express "^4.18.2"
+    passport "^0.7.0"
+
 "@backstage/plugin-auth-backend-module-okta-provider@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend-module-okta-provider/-/plugin-auth-backend-module-okta-provider-0.0.6.tgz#a22dfd5923244fb6f0d8fb60e07d8c11656006df"
@@ -3017,6 +3120,65 @@
     "@davidzemon/passport-okta-oauth" "^0.0.5"
     express "^4.18.2"
     passport "^0.7.0"
+
+"@backstage/plugin-auth-backend@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-backend/-/plugin-auth-backend-0.21.0.tgz#a36f1f4d110f176c00bae2245bc14e4bbf0b2aaf"
+  integrity sha512-3mBsa9l5d0LKthxr8mayG/c7/O/MSRPE+KR+E/zvyb/df6M0UtdqkpRBPXymlqolTfpwaFmCh/7IVxG1DysP0Q==
+  dependencies:
+    "@backstage/backend-common" "^0.21.0"
+    "@backstage/backend-plugin-api" "^0.6.10"
+    "@backstage/catalog-client" "^1.6.0"
+    "@backstage/catalog-model" "^1.4.4"
+    "@backstage/config" "^1.1.1"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/plugin-auth-backend-module-atlassian-provider" "^0.1.2"
+    "@backstage/plugin-auth-backend-module-aws-alb-provider" "^0.1.0"
+    "@backstage/plugin-auth-backend-module-gcp-iap-provider" "^0.2.4"
+    "@backstage/plugin-auth-backend-module-github-provider" "^0.1.7"
+    "@backstage/plugin-auth-backend-module-gitlab-provider" "^0.1.7"
+    "@backstage/plugin-auth-backend-module-google-provider" "^0.1.7"
+    "@backstage/plugin-auth-backend-module-microsoft-provider" "^0.1.5"
+    "@backstage/plugin-auth-backend-module-oauth2-provider" "^0.1.7"
+    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider" "^0.1.2"
+    "@backstage/plugin-auth-backend-module-oidc-provider" "^0.1.0"
+    "@backstage/plugin-auth-backend-module-okta-provider" "^0.0.3"
+    "@backstage/plugin-auth-node" "^0.4.4"
+    "@backstage/plugin-catalog-node" "^1.7.0"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/firestore" "^7.0.0"
+    "@node-saml/passport-saml" "^4.0.4"
+    "@types/express" "^4.17.6"
+    "@types/passport" "^1.0.3"
+    compression "^1.7.4"
+    connect-session-knex "^4.0.0"
+    cookie-parser "^1.4.5"
+    cors "^2.8.5"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    express-session "^1.17.1"
+    fs-extra "^11.2.0"
+    google-auth-library "^8.0.0"
+    jose "^4.6.0"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+    minimatch "^5.0.0"
+    morgan "^1.10.0"
+    node-cache "^5.1.2"
+    node-fetch "^2.6.7"
+    openid-client "^5.2.1"
+    passport "^0.7.0"
+    passport-auth0 "^1.4.3"
+    passport-bitbucket-oauth2 "^0.1.2"
+    passport-github2 "^0.1.12"
+    passport-google-oauth20 "^2.0.0"
+    passport-microsoft "^1.0.0"
+    passport-oauth2 "^1.6.1"
+    passport-onelogin-oauth "^0.0.1"
+    uuid "^8.0.0"
+    winston "^3.2.1"
+    yn "^4.0.0"
 
 "@backstage/plugin-auth-backend@0.21.3", "@backstage/plugin-auth-backend@^0.21.3":
   version "0.21.3"
@@ -3076,6 +3238,29 @@
     uuid "^8.0.0"
     winston "^3.2.1"
     yn "^4.0.0"
+
+"@backstage/plugin-auth-node@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.4.5.tgz#b48fcce866c91c953ab3cbb9301a28e0dc9dc527"
+  integrity sha512-hu7GO6yDZURpXoeOt/DgJqDnhYQ3h1UnGLDr7VhHuIfAcwrTj8Onrb+HbmrdwAUSXguHZzM8pyPeBA+dU/jOjA==
+  dependencies:
+    "@backstage/backend-common" "^0.21.0"
+    "@backstage/backend-plugin-api" "^0.6.10"
+    "@backstage/catalog-client" "^1.6.0"
+    "@backstage/catalog-model" "^1.4.4"
+    "@backstage/config" "^1.1.1"
+    "@backstage/errors" "^1.2.3"
+    "@backstage/types" "^1.1.1"
+    "@types/express" "*"
+    "@types/passport" "^1.0.3"
+    express "^4.17.1"
+    jose "^4.6.0"
+    lodash "^4.17.21"
+    node-fetch "^2.6.7"
+    passport "^0.7.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.21.4"
 
 "@backstage/plugin-auth-node@0.4.8", "@backstage/plugin-auth-node@^0.4.4", "@backstage/plugin-auth-node@^0.4.8":
   version "0.4.8"
@@ -3382,7 +3567,7 @@
     react-use "^17.2.4"
     yaml "^2.0.0"
 
-"@backstage/plugin-catalog-node@1.7.3", "@backstage/plugin-catalog-node@^1.7.3":
+"@backstage/plugin-catalog-node@1.7.3", "@backstage/plugin-catalog-node@^1.7.0", "@backstage/plugin-catalog-node@^1.7.3":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-node/-/plugin-catalog-node-1.7.3.tgz#a7369ed5bebddd82adb7417b86f1670a1a9f14d8"
   integrity sha512-Y6DgN2PSdUMndWjx+a8Vm6AU7NS40hzgbDfeVR50rRNMhL4g3SyTXKgiSxiijdl6eRnnUHaqt+ux5/iy/B7jCQ==
@@ -13775,7 +13960,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie-parser@^1.4.5:
+cookie-parser@1.4.6, cookie-parser@^1.4.5:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
   integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
@@ -13798,6 +13983,11 @@ cookie@0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
+cookie@0.4.2, cookie@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
 cookie@0.5.0, cookie@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
@@ -13807,11 +13997,6 @@ cookie@0.6.0, cookie@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
-
-cookie@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookiejar@^2.1.4:
   version "2.1.4"
@@ -15905,6 +16090,20 @@ express-rate-limit@7.1.5:
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.1.5.tgz#af4c81143a945ea97f2599d13957440a0ddbfcfe"
   integrity sha512-/iVogxu7ueadrepw1bS0X0kaRC/U0afwiYRSLg68Ts+p4Dc85Q5QKsOnPS/QUjPMHvOJQtBDrZgvkOzf8ejUYw==
 
+express-session@1.17.3:
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.3.tgz#14b997a15ed43e5949cb1d073725675dd2777f36"
+  integrity sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==
+  dependencies:
+    cookie "0.4.2"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-headers "~1.0.2"
+    parseurl "~1.3.3"
+    safe-buffer "5.2.1"
+    uid-safe "~2.1.5"
+
 express-session@^1.17.1:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.18.0.tgz#a6ae39d9091f2efba5f20fc5c65a3ce7c9ce16a3"
@@ -16965,7 +17164,7 @@ graphql-ws@^5.14.0, graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.15.0.tgz#2db79e1b42468a8363bf5ca6168d076e2f8fdebc"
   integrity sha512-xWGAtm3fig9TIhSaNsg0FaDZ8Pyn/3re3RFlP4rhQcmjRDIPpk1EhRuNB+YSJtLzttyuToaDiNhwT1OMoGnJnw==
 
-graphql@^16.0.0, graphql@^16.8.1:
+"graphql@^15.0.0 || ^16.0.0", graphql@^16.0.0, graphql@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
   integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
@@ -18663,6 +18862,16 @@ jmespath@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha512-+kHj8HXArPfpPEKGLZ+kB5ONRTCiGQXo8RQYL0hH8t6pWXUBBK5KkkQmTNOwKK4LEsd0yTsgtjJVm4UBSZea4w==
+
+jose@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.0.0.tgz#3fa13b97c8c0147deeef23961464a48d7bdb21ae"
+  integrity sha512-CzP0RPWMzo5oXfCSo+qA0Zz8enk1cI3Hpqzpz1o8Pck4xfFZqxC6OXRqEsAUzSTEl08fiuvU9xIbkoY1zeOg2w==
+
+jose@^4.14.4:
+  version "4.15.5"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.5.tgz#6475d0f467ecd3c630a1b5dadd2735a7288df706"
+  integrity sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==
 
 jose@^4.15.4, jose@^4.6.0:
   version "4.15.5"
@@ -20529,6 +20738,31 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.3.1.tgz#84a12bb17e76c25a7accaf921317044907ccd501"
+  integrity sha512-GhP5lHSTXNlZb9EaKgPRJ01YAnVXwzkvnTzRn4W8fxU2DXuJrRO+Nb6OHdYqB4fCkwSNpIJH9JkON5Y6rHqJMQ==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.10"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "^4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^15.0.0 || ^16.0.0"
+    headers-polyfill "3.2.5"
+    inquirer "^8.2.0"
+    is-node-process "^1.2.0"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.4.0"
+    path-to-regexp "^6.2.0"
+    strict-event-emitter "^0.4.3"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
+
 msw@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/msw/-/msw-2.2.1.tgz#5ece7ee81331aabe632fe331f07e71e8a3949499"
@@ -21172,6 +21406,16 @@ openapi3-ts@^3.1.2:
   dependencies:
     yaml "^2.2.1"
 
+openid-client@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.5.0.tgz#0c631b33c6a2c3e01197506978d6bff70e75c858"
+  integrity sha512-Y7Xl8BgsrkzWLHkVDYuroM67hi96xITyEDSkmWaGUiNX6CkcXC3XyQGdv5aWZ6dukVKBFVQCADi9gCavOmU14w==
+  dependencies:
+    jose "^4.14.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.3"
+
 openid-client@^5.2.1, openid-client@^5.3.0, openid-client@^5.5.0:
   version "5.6.4"
   resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.6.4.tgz#b2c25e6d5338ba3ce00e04341bb286798a196177"
@@ -21558,19 +21802,19 @@ passport-strategy@1.x.x, passport-strategy@^1.0.0:
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
   integrity sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==
 
-passport@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/passport/-/passport-0.6.0.tgz#e869579fab465b5c0b291e841e6cc95c005fac9d"
-  integrity sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==
+passport@0.7.0, passport@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.7.0.tgz#3688415a59a48cf8068417a8a8092d4492ca3a05"
+  integrity sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==
   dependencies:
     passport-strategy "1.x.x"
     pause "0.0.1"
     utils-merge "^1.0.1"
 
-passport@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/passport/-/passport-0.7.0.tgz#3688415a59a48cf8068417a8a8092d4492ca3a05"
-  integrity sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==
+passport@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.6.0.tgz#e869579fab465b5c0b291e841e6cc95c005fac9d"
+  integrity sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==
   dependencies:
     passport-strategy "1.x.x"
     pause "0.0.1"
@@ -24672,7 +24916,7 @@ sucrase@^3.20.2:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
-superagent@^8.1.2:
+superagent@^8.0.5, superagent@^8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.1.2.tgz#03cb7da3ec8b32472c9d20f6c2a57c7f3765f30b"
   integrity sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==
@@ -24687,6 +24931,14 @@ superagent@^8.1.2:
     mime "2.6.0"
     qs "^6.11.0"
     semver "^7.3.8"
+
+supertest@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
+  integrity sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.0.5"
 
 supertest@6.3.4:
   version "6.3.4"


### PR DESCRIPTION
## Description

Forked the Auth backend OIDC provider module from Upstream into the Showcase. The purpose of this is to address the sign-out issue currently faced by users who are using OAuth2 Proxy and Keycloak. This fork will enable them to switch to the OIDC provider and Keycloak, providing the ability to log out properly.

This PR also introduces some documentation on configuring auth providers within showcase. I settled for the inclusion of a few simple providers with very little detail at this time, with the exception of the OIDC provider. With this provider, I opted to an additional example since we will be trying to recommend this over OAuth2 Proxy.

If we wish to expand upon this further, I believe we should open up a separate issue that tackles the auth providers as a whole. Just wanted to at least have something available to begin the work.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

The example given within the documentation should be sufficient for testing the OIDC provider with a Keycloak instance. This example can be found in `auth.md` under the section titled `OIDC`.

Also, the changes that were made include: 
- `packages/backend/package.json` where the internal plugin was added
- `packages/backend/src/modules/authProvidersModule.ts` where we are using the forked OIDC module
- `plugins/auth-backend-module-oidc-provider/package.json` pin dependencies, update the name to internal, remove start script
- `plugins/auth-backend-module-oidc-provider/src/authenticator.ts` adds logout on Line 186 
- `showcase-docs/auth.md` adds some basic authentication docs with a few providers listed as a starting point
- `showcase-docs/getting-started.md` updates the authentication section to point to the new auth doc

Everything else surrounding the forked plugin has been relatively left in tact with the exception of the removal of the changelog, api-report, etc.

EDIT:
Some more changes that were made to fix the failing CI
- `plugins/auth-backend-module-oidc-provider/authenticator.test.ts` and `module.test.ts` added comment for sonarcloud to ignore a couple of URLs in the test
- `.rhdh/docker/Dockerfile` and `docker/Dockerfile` added the plugin module to the dockerfile.