### PR TITLE
plugin-scalprum-backend: replace mock-fs with @backstage/backend-test…

### DIFF
--- a/plugins/scalprum-backend/package.json
+++ b/plugins/scalprum-backend/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@backstage/backend-common": "0.21.3",
-    "@backstage/backend-plugin-api": "0.6.13",
     "@backstage/backend-dynamic-feature-service": "0.2.3",
+    "@backstage/backend-plugin-api": "0.6.13",
     "@backstage/config": "1.1.1",
     "@types/express": "4.17.21",
     "express": "4.18.2",
@@ -33,9 +33,10 @@
     "winston": "3.11.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "^0.3.3",
     "@backstage/cli": "0.25.2",
-    "@types/supertest": "6.0.2",
     "@types/mock-fs": "4.13.4",
+    "@types/supertest": "6.0.2",
     "mock-fs": "5.2.0",
     "msw": "2.2.1",
     "supertest": "6.3.4"


### PR DESCRIPTION
…-utils

mock-fs does not work with Node.js 20.8.0 and later, so we replace it with @backstage/backend-test-utils from upstream.

First time digging into this code so 🤞🏻 
## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Refs: #880

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing

## How to test changes / Special notes to the reviewer
