### PR TITLE
chore(deps): bump tekton plugin to 3.5.12

### DIFF
--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -28,7 +28,7 @@
     "@janus-idp/backstage-plugin-ocm-backend": "3.5.7",
     "@janus-idp/backstage-plugin-quay": "1.5.9",
     "@janus-idp/backstage-plugin-rbac": "1.15.3",
-    "@janus-idp/backstage-plugin-tekton": "3.5.11",
+    "@janus-idp/backstage-plugin-tekton": "3.5.12",
     "@janus-idp/backstage-plugin-topology": "1.18.7",
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.3.5",
     "@janus-idp/backstage-scaffolder-backend-module-regex": "1.3.5",


### PR DESCRIPTION

## Description

Bump the tekton plugin to include the ACS report crashing UI.

## Which issue(s) does this PR fix

-  https://github.com/janus-idp/backstage-plugins/issues/1355
- https://github.com/janus-idp/backstage-plugins/releases/tag/%40janus-idp%2Fbackstage-plugin-tekton%403.5.12

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer


cc: @nickboldt 