### PR TITLE
fix(deps): declare @smithy/is-array-buffer in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@backstage/cli": "0.25.2",
     "@smithy/util-utf8": "2.1.1",
+    "@smithy/is-array-buffer": "2.1.1",
     "@spotify/prettier-config": "15.0.0",
     "cross-var": "1.1.0",
     "husky": "8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9635,6 +9635,13 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@smithy/is-array-buffer@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz#07b4c77ae67ed58a84400c76edd482271f9f957b"
+  integrity sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==
+  dependencies:
+    tslib "^2.5.0"
+
 "@smithy/is-array-buffer@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz#29948072da2b57575aa9898cda863932e842ab11"


### PR DESCRIPTION
## Description

Declare the dependency `@smithy/is-array-buffer@2.1.1` in the package.json. We are still having some build issues that might be linked to this dependency no longer being explicitly available in the yarn lock file. It was originally removed whenever the OIDC auth plugin module was added in favor of `@smithy/is-array-buffer@^2.2.0`. For some reason, it is not being properly picked up during our build process so this PR aims to declare it explicitly.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
