### PR TITLE
chore(deps): bump topology plugin to 1.18.8

### DIFF
--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -29,7 +29,7 @@
     "@janus-idp/backstage-plugin-quay": "1.5.9",
     "@janus-idp/backstage-plugin-rbac": "1.15.3",
     "@janus-idp/backstage-plugin-tekton": "3.5.12",
-    "@janus-idp/backstage-plugin-topology": "1.18.7",
+    "@janus-idp/backstage-plugin-topology": "1.18.8",
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.3.5",
     "@janus-idp/backstage-scaffolder-backend-module-regex": "1.3.5",
     "@janus-idp/backstage-scaffolder-backend-module-servicenow": "1.3.5",


### PR DESCRIPTION
## Description

Bump the topology plugin to include the fix for routes sown for workloads with same name, across namespaces

## Which issue(s) does this PR fix

- Fixes #?

- https://issues.redhat.com/browse/RHTAPBUGS-1166
- https://issues.redhat.com/browse/RHIDP-1693
- https://github.com/janus-idp/backstage-plugins/pull/1389
- https://github.com/janus-idp/backstage-plugins/releases/tag/%40janus-idp%2Fbackstage-plugin-topology%401.18.8



## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
