### PR TITLE
chore(deps): add @smithy/is-array-buffer...chore(deps): add @smithy/is-array-buffer 2.1.1 and util-buffer-from 2.1.1 to make cachito happy with 3scale plugin 1.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   "devDependencies": {
     "@backstage/cli": "0.25.2",
     "@smithy/util-utf8": "2.1.1",
+    "@smithy/is-array-buffer": "2.1.1",
+    "@smithy/util-buffer-from": "2.1.1",
     "@spotify/prettier-config": "15.0.0",
     "cross-var": "1.1.0",
     "husky": "8.0.3",


### PR DESCRIPTION
### What does this PR do?

chore(deps): add @smithy/is-array-buffer 2.1.1 and util-buffer-from 2.1.1 to make cachito happy with 3scale plugin 1.4.7

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
fix for

```
2024-03-27 11:56:42,980 - atomic_reactor.tasks.binary_container_build - INFO - error An unexpected error occurred: "https://cachito-nexus.engineering.redhat.com/repository/cachito-yarn-1292208//@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz: Request failed \"404 Not Found\"".
```

same fix as https://github.com/janus-idp/backstage-showcase/pull/1143

Once 3scale 1.4.8 is out, we probably don't need this; instad we should remove the smithy 2.1.1 reference. 

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.