### PR TITLE
chore(renovate): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,17 +33,28 @@
       "groupName": ["Docker base images"]
     },
     {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": ["DevDependencies (non-major)"]
+    },
+    {
       "matchPackagePatterns": [
         "^@backstage/",
         "^@janus-idp/",
         "^@immobiliarelabs/",
         "^@roadiehq/",
-        "^@pagerduty/"
+        "^@pagerduty/",
+        "^@internal/"
       ],
       "groupName": ["Backstage packages"],
       "dependencyDashboardApproval": true
     }
   ],
   "ignorePaths": ["**/dist-dynamic/**"],
-  "ignoreDeps": ["@roadiehq/backstage-plugin-argo-cd"]
+  "ignoreDeps": ["@roadiehq/backstage-plugin-argo-cd"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["kind/security"]
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix
* Added a package rule for devDependencies.  Let's wait and see before adding automerge
* Included the  `@internal` package so static backend plugins are scanned
* Added configs for vulnerabilityAlerts and osvVulnerabilityAlerts - similar to what was done for the operator: https://github.com/janus-idp/operator/pull/282.  Will switch off dependabot PR creation once this is merged

- Fixes https://issues.redhat.com/browse/RHIDP-1737

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
