### PR TITLE
fix(ui): match table styles with PF5

### DIFF
--- a/packages/app/src/themes/componentOverrides.ts
+++ b/packages/app/src/themes/componentOverrides.ts
@@ -99,6 +99,12 @@ export const components = (
             backgroundColor: themePalette.general.cardBorderColor,
           },
         },
+        elevation2: {
+          backgroundColor: themePalette.general.tableBackgroundColor,
+          boxShadow: 'none',
+          outline: `1px solid ${themePalette.general.cardBorderColor}`,
+          padding: '1rem',
+        },
       },
     },
     MuiAccordion: {
@@ -114,6 +120,80 @@ export const components = (
           '&:last-child': {
             borderBottomLeftRadius: '0',
             borderBottomRightRadius: '0',
+          },
+        },
+      },
+    },
+    MuiTable: {
+      styleOverrides: {
+        root: {
+          backgroundColor: themePalette.general.tableBackgroundColor,
+        },
+      },
+    },
+    MuiToolbar: {
+      styleOverrides: {
+        regular: {
+          '& > div > h2[class*="MuiTypography-h5"]': {
+            fontSize: '1.25rem',
+            color: themePalette.general.tableTitleColor,
+          },
+        },
+      },
+    },
+    MuiTableRow: {
+      styleOverrides: {
+        root: {
+          backgroundColor: themePalette.general.tableBackgroundColor,
+          '&:not([class*="MuiTableRow-footer"]):hover': {
+            backgroundColor: `${themePalette.general.tableRowHover} !important`,
+          },
+          '& > th[class*="MuiTableCell-head"]': {
+            backgroundColor: themePalette.general.tableBackgroundColor,
+          },
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+          '&[class*="BackstageTableHeader-header"]': {
+            borderTop: 'unset',
+            borderBottom: `1px solid ${themePalette.general.tableBorderColor}`,
+          },
+        },
+        // @ts-ignore
+        head: {
+          textTransform: 'unset !important',
+          color: `${themePalette.general.tableColumnTitleColor} !important`,
+          '& > span[class*="MuiTableSortLabel-active"]': {
+            color: `${themePalette.general.tableColumnTitleActiveColor} !important`,
+          },
+          '& > span > svg[class*="MuiTableSortLabel-icon"]': {
+            color: 'inherit !important',
+          },
+        },
+        body: {
+          fontWeight: 'normal !important',
+          color: themePalette.general.tableTitleColor,
+          '&:empty::before': {
+            content: '"--"',
+          },
+          '& > div > span:empty::before': {
+            content: '"--"',
+          },
+          '& > div[class*="MuiChip-sizeSmall"]': {
+            margin: '2px',
+          },
+        },
+      },
+    },
+    MuiTableFooter: {
+      styleOverrides: {
+        root: {
+          '& > tr > td': {
+            borderBottom: 'none',
           },
         },
       },

--- a/packages/app/src/themes/defaultThemePalette.ts
+++ b/packages/app/src/themes/defaultThemePalette.ts
@@ -11,6 +11,13 @@ export const defaultThemePalette = (mode: string) => {
         sideBarBackgroundColor: '#1b1d21',
         cardSubtitleColor: '#FFF',
         cardBorderColor: '#444548',
+        tableTitleColor: '#E0E0E0',
+        tableSubtitleColor: '#E0E0E0',
+        tableColumnTitleColor: '#E0E0E0',
+        tableColumnTitleActiveColor: '#1FA7F8',
+        tableRowHover: '#0f1214',
+        tableBorderColor: '#515151',
+        tableBackgroundColor: '#1b1d21',
       },
       primary: {
         main: '#1FA7F8', // text button color, button background color
@@ -39,6 +46,13 @@ export const defaultThemePalette = (mode: string) => {
       sideBarBackgroundColor: '#212427',
       cardSubtitleColor: '#000',
       cardBorderColor: '#EBEBEB',
+      tableTitleColor: '#181818',
+      tableSubtitleColor: '#616161',
+      tableColumnTitleColor: '#151515',
+      tableColumnTitleActiveColor: '#0066CC',
+      tableRowHover: '#F5F5F5',
+      tableBorderColor: '#E0E0E0',
+      tableBackgroundColor: '#FFF',
     },
     primary: {
       main: '#0066CC',


### PR DESCRIPTION
## Description

Match table styles with PF5.

## Which issue(s) does this PR fix

- Fixes [RHIDP-1707](https://issues.redhat.com/browse/RHIDP-1707): Add MUI theme config so that Tables look similar to PF5

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## Screen recording(updated on 4.5)

https://github.com/janus-idp/backstage-showcase/assets/26255262/5bfd8597-2bcb-44c1-9691-d9c23dcd425a




