### PR TITLE
fix(template): fixed template cards display issues

### DIFF
--- a/packages/app/src/themes/componentOverrides.ts
+++ b/packages/app/src/themes/componentOverrides.ts
@@ -98,6 +98,11 @@ export const components = (
           '& > hr[class|="MuiDivider-root"]': {
             backgroundColor: themePalette.general.cardBorderColor,
           },
+          '&[class*="MuiPaper-root-"][class*="MuiCard-root-"][class*="MuiPaper-elevation1-"][class*="MuiPaper-rounded-"]':
+            {
+              display: 'flex',
+              flexDirection: 'column',
+            },
         },
         elevation2: {
           backgroundColor: themePalette.general.tableBackgroundColor,
@@ -229,6 +234,10 @@ export const components = (
           '& > div[class*="MuiAccordion-root"]:before': {
             height: 0,
           },
+          '& > div[class*="MuiGrid-root-"][class*="MuiGrid-container-"][class*="MuiGrid-spacing-xs-2-"] > div[class*="MuiGrid-root-"][class*="MuiGrid-item-"][class*="MuiGrid-grid-xs-12-"] > div[class*="MuiBox-root-"][class*="makeStyles-box"]':
+            {
+              '-webkit-line-clamp': '2',
+            },
         },
       },
     },


### PR DESCRIPTION
## Description

Template cards height is too big in 1.1.x and bottom section is hidden in main branch.

## Which issue(s) does this PR fix

- Fixes [RHIDP-1927](https://issues.redhat.com/browse/RHIDP-1927): Default card height for templates is more by default and bottom section is hidden

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
<img width="1512" alt="rhidp_1927_template_cards_display" src="https://github.com/janus-idp/backstage-showcase/assets/26255262/9da062f2-5182-4b70-afb8-9ee3e120c972">
