### PR TITLE
fix(ui): match styles with PF5

### DIFF
--- a/packages/app/src/themes/componentOverrides.ts
+++ b/packages/app/src/themes/componentOverrides.ts
@@ -2,32 +2,49 @@ import { UnifiedThemeOptions } from '@backstage/theme';
 import { defaultThemePalette } from './defaultThemePalette';
 import { ThemeColors } from '../types/types';
 
-const redhatFont = `@font-face {
-  font-family: 'Red Hat Font';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url(/fonts/RedHatText-Regular.woff2) format('woff2'),
+export const redHatFont = {
+  fontFamily: '"Red Hat Text", Helvetica, helvetica, arial, sans-serif',
+  src: `url(/fonts/RedHatText-Regular.woff2) format('woff2'),
     url(/fonts/RedHatText-Regular.otf) format('opentype'),
-    url(/fonts/RedHatText-Regular.ttf) format('truetype');
-}`;
+    url(/fonts/RedHatText-Regular.ttf) format('truetype')`,
+};
 
 export const components = (
   themeColors: ThemeColors,
   mode: string,
 ): UnifiedThemeOptions['components'] => {
-  const themePalette = defaultThemePalette(mode);
+  const themePalette = defaultThemePalette(mode, themeColors);
   return {
+    MuiTypography: {
+      styleOverrides: {
+        button: {
+          textTransform: 'none',
+          fontWeight: 'bold',
+        },
+      },
+    },
     BackstageHeaderTabs: {
       styleOverrides: {
         tabsWrapper: {
           paddingLeft: '0',
+          backgroundColor: themePalette.general.mainSectionBackgroundColor,
         },
         defaultTab: {
           textTransform: 'none',
-          fontSize: '0.875rem',
+          fontSize: '1rem',
+          fontWeight: '500',
+          color: themePalette.general.disabled,
+          padding: '0.5rem 1rem',
           '&:hover': {
-            boxShadow: '0 -3px #b8bbbe inset',
+            boxShadow: `0 -3px ${themePalette.general.tabsBottomBorderColor} inset`,
+          },
+        },
+        tabRoot: {
+          '&:hover': {
+            backgroundColor: 'unset',
+          },
+          '&:not(.Mui-selected):hover': {
+            color: themePalette.general.disabled,
           },
         },
       },
@@ -37,13 +54,15 @@ export const components = (
         TabIndicatorProps: {
           style: {
             height: '3px',
-            background: themeColors.navigationIndicatorColor || '#0066CC',
+            background:
+              themeColors.navigationIndicatorColor || themePalette.primary.main,
           },
         },
       },
       styleOverrides: {
         root: {
-          borderBottom: '1px solid #d2d2d2',
+          boxShadow: `0 -1px ${themePalette.general.tabsBottomBorderColor} inset`,
+          padding: '0 1.5rem',
         },
       },
     },
@@ -56,7 +75,7 @@ export const components = (
           textTransform: 'none',
           minWidth: 'initial !important',
           '&.Mui-disabled': {
-            backgroundColor: '#d2d2d2',
+            backgroundColor: themePalette.general.disabledBackground,
           },
         },
       },
@@ -68,6 +87,22 @@ export const components = (
         },
       },
     },
+    BackstageSidebarItem: {
+      styleOverrides: {
+        label: {
+          '&[class*="MuiTypography-subtitle2"]': {
+            fontWeight: '500',
+          },
+        },
+      },
+    },
+    BackstagePage: {
+      styleOverrides: {
+        root: {
+          overflow: 'scroll',
+        },
+      },
+    },
     BackstageContent: {
       styleOverrides: {
         root: {
@@ -75,9 +110,123 @@ export const components = (
           '& div:first-child': {
             '& > div[class*="-searchBar"]': {
               backgroundColor: themePalette.general.formControlBackgroundColor,
-              boxShadow: `0px 2px 1px -1px ${themePalette.general.disabled}`,
+              border: `1px solid ${themePalette.general.searchBarBorderColor}`,
+              boxShadow: 'none',
             },
           },
+          '& > div[class*="-MuiGrid-root"]': {
+            marginLeft: '0',
+            width: '100%',
+          },
+          '& > div[class*="MuiGrid-root"][class*="MuiGrid-container"][class*="MuiGrid-spacing-xs-3"] > div[class*="MuiGrid-item"]:nth-child(odd)':
+            {
+              paddingLeft: '0',
+            },
+          '& > div[class*="MuiGrid-root"][class*="MuiGrid-container"][class*="MuiGrid-spacing-xs-6"] > div[class*="MuiGrid-item"][class*="MuiGrid-grid-xs-12"]':
+            {
+              paddingLeft: '0',
+            },
+        },
+      },
+    },
+    BackstageContentHeader: {
+      styleOverrides: {
+        leftItemsBox: {
+          '& > h2[class*="BackstageContentHeader-title-"][class*="MuiTypography-h4-"]':
+            {
+              fontWeight: 'bold',
+              fontSize: '1.75rem',
+            },
+        },
+      },
+    },
+    BackstageHeader: {
+      styleOverrides: {
+        header: {
+          backgroundImage: `none, linear-gradient(90deg, ${themeColors.headerColor1}, ${themeColors.headerColor2})`,
+          backgroundColor: themePalette.general.headerBackgroundColor,
+          boxShadow: 'none',
+        },
+        title: {
+          color: themePalette.general.cardSubtitleColor,
+          fontWeight: 'bold',
+          '&[class*="MuiTypography-h1-"]': {
+            fontWeight: 'bold',
+            fontSize: '2rem',
+          },
+        },
+        leftItemsBox: {
+          color: themePalette.general.headerTextColor,
+          '& > nav': {
+            color: themePalette.general.headerTextColor,
+          },
+          '& > p': {
+            color: themePalette.general.headerTextColor,
+          },
+          '& > span': {
+            color: themePalette.general.headerTextColor,
+          },
+        },
+        rightItemsBox: {
+          color: themePalette.general.headerTextColor,
+          '& div': {
+            color: themePalette.general.headerTextColor,
+          },
+          '& p': {
+            color: themePalette.general.headerTextColor,
+          },
+          '& a': {
+            color: themePalette.general.headerTextColor,
+          },
+          '& button': {
+            color: themePalette.general.headerTextColor,
+          },
+        },
+      },
+    },
+    BackstageItemCardHeader: {
+      styleOverrides: {
+        root: {
+          '&[class*="makeStyles-header-"]': {
+            backgroundImage: 'none',
+            borderBottom: `1px solid ${themePalette.general.cardBorderColor}`,
+          },
+          '& > h3[class*="MuiTypography-subtitle2-"] > div[class*="makeStyles-subtitleWrapper-"] > div:first-child':
+            {
+              color: themePalette.general.tableSubtitleColor,
+              textTransform: 'capitalize',
+            },
+          '& > h3[class*="MuiTypography-subtitle2-"] > div[class*="makeStyles-subtitleWrapper-"] > div:last-child':
+            {
+              color: themePalette.general.cardSubtitleColor,
+            },
+          '& > h4[class*="MuiTypography-h6-"]': {
+            color: themePalette.general.cardSubtitleColor,
+          },
+        },
+      },
+    },
+    BackstageTableToolbar: {
+      styleOverrides: {
+        root: {
+          '& h2': {
+            fontWeight: 'bold',
+          },
+        },
+        title: {
+          '& > h2': {
+            fontWeight: 'bold',
+          },
+        },
+      },
+    },
+    CatalogReactUserListPicker: {
+      styleOverrides: {
+        root: {
+          borderRadius: '4px',
+        },
+        title: {
+          textTransform: 'none',
         },
       },
     },
@@ -404,7 +553,9 @@ export const components = (
       },
     },
     MuiCssBaseline: {
-      styleOverrides: redhatFont,
+      styleOverrides: {
+        '@font-face': [redHatFont],
+      },
     },
     MuiCardHeader: {
       styleOverrides: {

--- a/packages/app/src/themes/darkTheme.ts
+++ b/packages/app/src/themes/darkTheme.ts
@@ -1,10 +1,11 @@
 import { createUnifiedTheme, themes } from '@backstage/theme';
-import { components } from './componentOverrides';
+import { components, redHatFont } from './componentOverrides';
 import { pageTheme } from './pageTheme';
 import { ThemeColors } from '../types/types';
 
 export const customDarkTheme = (themeColors: ThemeColors) =>
   createUnifiedTheme({
+    fontFamily: redHatFont.fontFamily,
     palette: {
       ...themes.dark.getTheme('v5')?.palette,
       ...(themeColors.primaryColor && {

--- a/packages/app/src/themes/defaultThemePalette.ts
+++ b/packages/app/src/themes/defaultThemePalette.ts
@@ -1,11 +1,16 @@
-export const defaultThemePalette = (mode: string) => {
+import { ThemeColors } from '../types/types';
+
+export const defaultThemePalette = (mode: string, themeColors: ThemeColors) => {
   if (mode === 'dark') {
     return {
       general: {
         disabledBackground: '#444548',
         disabled: '#AAABAC',
+        searchBarBorderColor: '#57585a',
         formControlBackgroundColor: '#36373A',
         mainSectionBackgroundColor: '#0f1214',
+        headerBackgroundColor: '#0f1214',
+        headerTextColor: '#FFF',
         cardBackgroundColor: '#212427',
         focusVisibleBorder: '#ADD6FF',
         sideBarBackgroundColor: '#1b1d21',
@@ -18,9 +23,10 @@ export const defaultThemePalette = (mode: string) => {
         tableRowHover: '#0f1214',
         tableBorderColor: '#515151',
         tableBackgroundColor: '#1b1d21',
+        tabsBottomBorderColor: '#444548',
       },
       primary: {
-        main: '#1FA7F8', // text button color, button background color
+        main: themeColors.primaryColor || '#1FA7F8', // text button color, button background color
         containedButtonBackground: '#0066CC', // contained button background color
         textHover: '#73BCF7', // text button hover color
         contrastText: '#FFF', // contained button text color
@@ -39,9 +45,12 @@ export const defaultThemePalette = (mode: string) => {
     general: {
       disabledBackground: '#D2D2D2',
       disabled: '#6A6E73',
+      searchBarBorderColor: '#E4E4E4',
       focusVisibleBorder: '#0066CC',
       formControlBackgroundColor: '#FFF',
-      mainSectionBackgroundColor: '#f0f0f0',
+      mainSectionBackgroundColor: '#FFF',
+      headerBackgroundColor: '#FFF',
+      headerTextColor: '#151515',
       cardBackgroundColor: '#FFF',
       sideBarBackgroundColor: '#212427',
       cardSubtitleColor: '#000',
@@ -53,9 +62,10 @@ export const defaultThemePalette = (mode: string) => {
       tableRowHover: '#F5F5F5',
       tableBorderColor: '#E0E0E0',
       tableBackgroundColor: '#FFF',
+      tabsBottomBorderColor: '#D2D2D2',
     },
     primary: {
-      main: '#0066CC',
+      main: themeColors.primaryColor || '#0066CC',
       containedButtonBackground: '#0066CC',
       mainHover: '#004080',
       contrastText: '#FFF',

--- a/packages/app/src/themes/lightTheme.ts
+++ b/packages/app/src/themes/lightTheme.ts
@@ -1,10 +1,11 @@
 import { createUnifiedTheme, themes } from '@backstage/theme';
-import { components } from './componentOverrides';
+import { components, redHatFont } from './componentOverrides';
 import { pageTheme } from './pageTheme';
 import { ThemeColors } from '../types/types';
 
 export const customLightTheme = (themeColors: ThemeColors) =>
   createUnifiedTheme({
+    fontFamily: redHatFont.fontFamily,
     palette: {
       ...themes.light.getTheme('v5')?.palette,
       ...(themeColors.primaryColor && {


### PR DESCRIPTION
## Description

This PR is for matching current style with PF5 style.
Main changes:
1. Overrode font-family to use Red Hat Text font
2. Updated main container background color to white
3. Updated header background color to white
4. Updated template cards style
5. Removed tabs background color
6. Updated tabs button style to display only one bottom border on tab selected
7. Added tabs padding
8. Replaced homepage search bar shadow with a border
9. Updated font weight and text transform for left side bar, page title and filter label text
10. Added border radius to catalog owner filter section


## Which issue(s) does this PR fix

- Fixes [RHIDP-1984](https://issues.redhat.com/browse/RHIDP-1984): Add MUI theme config so that background color and font look similar to PF5

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Screen recording (updated on **4/15**)


https://github.com/janus-idp/backstage-showcase/assets/26255262/86af6d88-89dc-4007-b516-0608efa8874c

