### PR TITLE
branding: add ability to customize sidebar logo

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -4,6 +4,7 @@ app:
   branding:
     fullLogo: ${BASE64_EMBEDDED_FULL_LOGO}
     iconLogo: ${BASE64_EMBEDDED_ICON_LOGO}
+    fullLogoSize: ${FULL_LOGO_SIZE}
     theme:
       light:
         primaryColor: ${PRIMARY_LIGHT_COLOR}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -4,7 +4,7 @@ app:
   branding:
     fullLogo: ${BASE64_EMBEDDED_FULL_LOGO}
     iconLogo: ${BASE64_EMBEDDED_ICON_LOGO}
-    fullLogoSize: ${FULL_LOGO_SIZE}
+    fullLogoWidth: ${FULL_LOGO_WIDTH}
     theme:
       light:
         primaryColor: ${PRIMARY_LIGHT_COLOR}

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -19,7 +19,7 @@ export interface Config {
        * The following units are supported: <number>, px, em, rem, <percentage>
        * @visibility frontend
        */
-      fullLogoSize?: string | number;
+      fullLogoWidth?: string | number;
       /**
        * Base64 URI for the icon logo
        * @visibility frontend

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -17,6 +17,7 @@ export interface Config {
       /**
        * size Configuration for the full logo
        * The following units are supported: <number>, px, em, rem, <percentage>
+       * @visibility frontend
        */
       fullLogoSize?: string | number;
       /**

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -15,6 +15,11 @@ export interface Config {
        */
       fullLogo?: string;
       /**
+       * size Configuration for the full logo
+       * The following units are supported: <number>, px, em, rem, <percentage>
+       */
+      fullLogoSize?: string | number;
+      /**
        * Base64 URI for the icon logo
        * @visibility frontend
        */

--- a/packages/app/src/components/Root/SidebarLogo.test.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.test.tsx
@@ -26,6 +26,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is open renders the component with full logo base64 provided by config', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue('fullLogoBase64URI'),
+      getOptional: jest.fn().mockReturnValue('fullLogoSize'),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: true });
@@ -43,6 +44,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is open renders the component with default full logo if config is undefined', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue(undefined),
+      getOptional: jest.fn().mockReturnValue(undefined),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: true });
@@ -58,6 +60,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is closed renders the component with icon logo base64 provided by config', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue('iconLogoBase64URI'),
+      getOptional: jest.fn().mockReturnValue('fullLogoSize'),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: false });
@@ -75,6 +78,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is closed renders the component with icon logo from default if not provided with config', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue(undefined),
+      getOptional: jest.fn().mockReturnValue(undefined),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: false });

--- a/packages/app/src/components/Root/SidebarLogo.test.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.test.tsx
@@ -26,7 +26,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is open renders the component with full logo base64 provided by config', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue('fullLogoBase64URI'),
-      getOptional: jest.fn().mockReturnValue('fullLogoSize'),
+      getOptional: jest.fn().mockReturnValue('fullLogoWidth'),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: true });
@@ -60,7 +60,7 @@ describe('SidebarLogo', () => {
   it('when sidebar is closed renders the component with icon logo base64 provided by config', () => {
     (useApi as any).mockReturnValue({
       getOptionalString: jest.fn().mockReturnValue('iconLogoBase64URI'),
-      getOptional: jest.fn().mockReturnValue('fullLogoSize'),
+      getOptional: jest.fn().mockReturnValue('fullLogoWidth'),
     });
 
     (useSidebarOpenState as any).mockReturnValue({ isOpen: false });

--- a/packages/app/src/components/Root/SidebarLogo.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.tsx
@@ -18,7 +18,7 @@ const LogoRender = ({
 }: {
   base64Logo: string | undefined;
   defaultLogo: React.JSX.Element;
-  width: number;
+  width: string | number;
 }) => {
   return base64Logo ? (
     <img
@@ -39,6 +39,7 @@ export const SidebarLogo = () => {
   const logoFullBase64URI = configApi.getOptionalString(
     'app.branding.fullLogo',
   );
+  const fullLogoSize = configApi.getOptionalString('app.branding.fullLogoSize');
   const logoIconBase64URI = configApi.getOptionalString(
     'app.branding.iconLogo',
   );
@@ -50,7 +51,7 @@ export const SidebarLogo = () => {
           <LogoRender
             base64Logo={logoFullBase64URI}
             defaultLogo={<LogoFull />}
-            width={110}
+            width={fullLogoSize ?? 110}
           />
         ) : (
           <LogoRender

--- a/packages/app/src/components/Root/SidebarLogo.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.tsx
@@ -39,8 +39,8 @@ export const SidebarLogo = () => {
   const logoFullBase64URI = configApi.getOptionalString(
     'app.branding.fullLogo',
   );
-  const fullLogoSize = configApi
-    .getOptional('app.branding.fullLogoSize')
+  const fullLogoWidth = configApi
+    .getOptional('app.branding.fullLogoWidth')
     ?.toString();
 
   const logoIconBase64URI = configApi.getOptionalString(
@@ -54,7 +54,7 @@ export const SidebarLogo = () => {
           <LogoRender
             base64Logo={logoFullBase64URI}
             defaultLogo={<LogoFull />}
-            width={fullLogoSize ?? 110}
+            width={fullLogoWidth ?? 110}
           />
         ) : (
           <LogoRender

--- a/packages/app/src/components/Root/SidebarLogo.tsx
+++ b/packages/app/src/components/Root/SidebarLogo.tsx
@@ -39,7 +39,10 @@ export const SidebarLogo = () => {
   const logoFullBase64URI = configApi.getOptionalString(
     'app.branding.fullLogo',
   );
-  const fullLogoSize = configApi.getOptionalString('app.branding.fullLogoSize');
+  const fullLogoSize = configApi
+    .getOptional('app.branding.fullLogoSize')
+    ?.toString();
+
   const logoIconBase64URI = configApi.getOptionalString(
     'app.branding.iconLogo',
   );

--- a/showcase-docs/customization.md
+++ b/showcase-docs/customization.md
@@ -7,12 +7,14 @@ To customize the look of your showcase instance, you can edit the `app-config.ya
 The sidebar uses two logos - one for the expanded sidebar and one for the collapsed sidebar.
 
 - To customize the logo for the expanded sidebar, provide a Base64 encoded image of your logo in the `app.branding.fullLogo` field of the `app-config.yaml`.
+- To change the width of logo, provide your required size of logo in the `app.branding.fullLogoSize` field of `app-config.yaml`
 - Similarly, to customize the logo for the collapsed sidebar, provide a Base64 encoded image of your logo in the `app.branding.iconLogo` field of the `app-config.yaml`:
 
 ```yaml title="app-config.yaml"
 app:
   branding:
     fullLogo: ${BASE64_EMBEDDED_FULL_LOGO} # SVG Example: data:image/svg+xml;base64,PD94...
+    fullLogoSize: ${FULL_LOGO_SIZE} # The following units are supported: <number>, px, em, rem, <percentage>
     iconLogo: ${BASE64_EMBEDDED_ICON_LOGO} # PNG Example: data:image/png;base64,iVBO...
 ```
 

--- a/showcase-docs/customization.md
+++ b/showcase-docs/customization.md
@@ -7,14 +7,14 @@ To customize the look of your showcase instance, you can edit the `app-config.ya
 The sidebar uses two logos - one for the expanded sidebar and one for the collapsed sidebar.
 
 - To customize the logo for the expanded sidebar, provide a Base64 encoded image of your logo in the `app.branding.fullLogo` field of the `app-config.yaml`.
-- To change the width of logo, provide your required size of logo in the `app.branding.fullLogoSize` field of `app-config.yaml`
+- To change the width of logo, provide your required size of logo in the `app.branding.fullLogoWidth` field of `app-config.yaml`
 - Similarly, to customize the logo for the collapsed sidebar, provide a Base64 encoded image of your logo in the `app.branding.iconLogo` field of the `app-config.yaml`:
 
 ```yaml title="app-config.yaml"
 app:
   branding:
     fullLogo: ${BASE64_EMBEDDED_FULL_LOGO} # SVG Example: data:image/svg+xml;base64,PD94...
-    fullLogoSize: ${FULL_LOGO_SIZE} # The following units are supported: <number>, px, em, rem, <percentage>
+    fullLogoWidth: ${FULL_LOGO_WIDTH} # The following units are supported: <number>, px, em, rem, <percentage>
     iconLogo: ${BASE64_EMBEDDED_ICON_LOGO} # PNG Example: data:image/png;base64,iVBO...
 ```
 


### PR DESCRIPTION
## Description
under app-config now you can set `fullLogoSize` to change width of the logo


## Which issue(s) does this PR fix
- Fixes #1203 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
Set the below in your config to change width of the logo
```
app:
  branding:
    fullLogoSize: ${FULL_LOGO_SIZE}
```