### PR TITLE
feat: tagRelease.sh bump versions in 1.1.x for 1.1 release

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showcase-app",
-  "version": "1.2.0",
+  "version": "1.1.3",
   "description": "Showcase E2E test",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/packages/app/src/build-metadata.json
+++ b/packages/app/src/build-metadata.json
@@ -1,4 +1,4 @@
 {
   "title": "RHDH Metadata",
-  "card": ["RHDH Version: 1.1.2", "Backstage Version: 1.23.4"]
+  "card": ["RHDH Version: 1.1.3", "Backstage Version: 1.23.4"]
 }


### PR DESCRIPTION
Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
