### PR TITLE
chore: remove ansi colors from logs

### DIFF
--- a/packages/backend/src/logger/customLogger.ts
+++ b/packages/backend/src/logger/customLogger.ts
@@ -37,7 +37,6 @@ const transports = {
     new winston.transports.Console({
       format: winston.format.combine(
         auditLogFormat({ isAuditLog: false }),
-        winston.format.colorize(),
         defaultFormat,
         winston.format.json(),
       ),
@@ -47,7 +46,6 @@ const transports = {
     new winston.transports.Console({
       format: winston.format.combine(
         auditLogFormat({ isAuditLog: true }),
-        winston.format.colorize(),
         defaultFormat,
         winston.format.json(),
       ),


### PR DESCRIPTION
## Description

Remove ansi colors from logs. After https://github.com/janus-idp/backstage-showcase/pull/1211 changed the log format to JSON, the ANSI escape sequences get outputted as plain text making the logs more difficult to parse through.

Ex:
```console
{"level":"\u001b[32minfo\u001b[39m","message":"::ffff:10.129.2.2 - - [03/May/2024:16:01:59 +0000] \"GET /healthcheck HTTP/1.1\" 200 15 \"-\" \"kube-probe/1.29\"","service":"rootHttpRouter","timestamp":"2024-05-03 16:01:59","type":"incomingRequest"}
```

## Which issue(s) does this PR fix

- Fixes [RHIDP-1632](https://issues.redhat.com/browse/RHIDP-1632)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
