### PR TITLE
fix(app): RHIDP-2266 add condition error handling

### DIFF
--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -36,7 +36,7 @@ type ScalprumMountPointConfigBase = {
 };
 
 export type ScalprumMountPointConfig = ScalprumMountPointConfigBase & {
-  if: (e: Entity) => boolean | Promise<boolean>;
+  if: (e: Entity) => boolean;
 };
 
 export type ScalprumMountPointConfigRawIf = {

--- a/packages/app/src/components/catalog/EntityPage/DynamicEntityTab.tsx
+++ b/packages/app/src/components/catalog/EntityPage/DynamicEntityTab.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box';
 import React from 'react';
 import getMountPointData from '../../../utils/dynamicUI/getMountPointData';
 import Grid from '../Grid';
+import { ApiHolder } from '@backstage/core-plugin-api';
 
 export type DynamicEntityTabProps = {
   path: string;
@@ -34,10 +35,20 @@ export const dynamicEntityTab = ({
     path={path}
     title={title}
     if={entity =>
-      (condition ? condition(entity) : Boolean(children)) ||
+      (condition
+        ? errorWrappedCondition(
+            `route path ${path} and title ${title}`,
+            condition,
+          )(entity)
+        : Boolean(children)) ||
       getMountPointData<React.ComponentType>(`${mountPoint}/cards`)
         .flatMap(({ config }) => config.if)
-        .some(cond => cond(entity))
+        .some(cond =>
+          errorWrappedCondition(
+            `route path ${path} and title ${title}`,
+            cond,
+          )(entity),
+        )
     }
   >
     {getMountPointData<React.ComponentType<React.PropsWithChildren>>(
@@ -55,7 +66,14 @@ export const dynamicEntityTab = ({
           ({ Component, config, staticJSXContent }, index) => {
             return (
               <EntitySwitch key={`${Component.displayName}-${index}`}>
-                <EntitySwitch.Case if={config.if}>
+                <EntitySwitch.Case
+                  if={(entity, context) =>
+                    errorWrappedCondition(
+                      `route path ${path}, title ${title} and mountPoint ${mountPoint}/cards`,
+                      config.if,
+                    )(entity, context)
+                  }
+                >
                   <Box sx={config.layout}>
                     <Component {...config.props}>{staticJSXContent}</Component>
                   </Box>
@@ -68,3 +86,21 @@ export const dynamicEntityTab = ({
     )}
   </EntityLayout.Route>
 );
+
+function errorWrappedCondition(
+  evaluationContext: string,
+  condition: (entity: Entity, context?: { apis: ApiHolder }) => boolean,
+): (entity: Entity, context?: { apis: ApiHolder }) => boolean {
+  return (entity: Entity, context?: { apis: ApiHolder }) => {
+    try {
+      return condition(entity, context);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Error evaluating conditional expression for ${evaluationContext}: `,
+        error,
+      );
+    }
+    return false;
+  };
+}

--- a/packages/app/src/utils/dynamicUI/getMountPointData.ts
+++ b/packages/app/src/utils/dynamicUI/getMountPointData.ts
@@ -3,7 +3,11 @@ import { ScalprumMountPointConfig } from '../../components/DynamicRoot/DynamicRo
 
 function getMountPointData<T = any, T2 = any>(
   mountPoint: string,
-): { config: ScalprumMountPointConfig; Component: T; staticJSXContent: T2 }[] {
+): {
+  config: ScalprumMountPointConfig;
+  Component: T;
+  staticJSXContent: T2;
+}[] {
   return getScalprum().api.mountPoints?.[mountPoint] ?? [];
 }
 


### PR DESCRIPTION
## Description

This change adds exception handling to the two points where plugin supplied condition functions are evaluated, once when rendering the catalog entity tabs, and a second time when a plugin's mountpoint configuration is being checked.  This change also makes the ApiHolder context object available as a 2nd argument; available at the second evaluation point.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2266](https://issues.redhat.com/browse/RHIDP-2266)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

An easy way to test this is to throw an exception from [here](https://github.com/gashcrumb/simple-test-components/blob/main/src/plugin.ts#L35) and use [this](https://github.com/gashcrumb/simple-test-components/tree/main#copy-build-results-to-host-application) plugin.  The configuration for this would look like:

```yaml
    backstage-plugin-simple-test-components:
      mountPoints:
        - mountPoint: entity.page.overview/cards
          importName: SimpleTestComponentsPage
          config:
            layout:
              gridColumn: "span 1"
              gridRow: "span 1"
            if:
              allOf:
                - isAvailableYes
            props:
              text: 'Content Block Two (always available)'
```

