### PR TITLE
fix(ui): RHIDP-2297 avoid duplicate config

### DIFF
--- a/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
@@ -1,5 +1,5 @@
-import { AppConfig } from '@backstage/config';
 import extractDynamicConfig, {
+  DynamicPluginConfig,
   conditionsArrayMapper,
   configIfToCallable,
 } from './extractDynamicConfig';
@@ -143,10 +143,8 @@ describe('extractDynamicConfig', () => {
       'no frontend dynamic plugins are defined',
       { dynamicPlugins: { frontend: {} } },
     ],
-  ])('returns empty data when %s', async (_, source) => {
-    const config = await extractDynamicConfig({
-      appConfig: [source] as AppConfig[],
-    });
+  ])('returns empty data when %s', (_, source) => {
+    const config = extractDynamicConfig(source as DynamicPluginConfig);
     expect(config).toEqual({
       routeBindings: [],
       dynamicRoutes: [],
@@ -430,16 +428,9 @@ describe('extractDynamicConfig', () => {
         ],
       },
     ],
-  ])('parses %s', async (_, source, output) => {
-    const config = await extractDynamicConfig({
-      appConfig: [
-        {
-          context: 'foo',
-          data: {
-            dynamicPlugins: { frontend: { 'janus-idp.plugin-foo': source } },
-          },
-        },
-      ] as AppConfig[],
+  ])('parses %s', (_, source: any, output) => {
+    const config = extractDynamicConfig({
+      frontend: { 'janus-idp.plugin-foo': source },
     });
     expect(config).toEqual({
       routeBindings: [],


### PR DESCRIPTION
## Description

This change overhauls the way in which the dynamic frontend configuration is obtained and evaluated, by first passing the loaded configuration through a ConfigReader vs directly evaluating the array of application configurations that the backend API returns.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2297](https://issues.redhat.com/browse/RHIDP-2297)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer