### PR TITLE
Allow replacing core plugins

### DIFF
--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -30,6 +30,10 @@ const AppBase = () => {
     entityTabOverrides,
     scaffolderFieldExtensions,
   } = useContext(DynamicRootContext);
+
+  const ifNotDynamic = (path: string, route: React.ReactElement) =>
+    dynamicRoutes.filter(({ path: p }) => p === path).length === 0 && route;
+
   return (
     <AppProvider>
       <AlertDisplay />
@@ -37,52 +41,80 @@ const AppBase = () => {
       <AppRouter>
         <Root>
           <FlatRoutes>
-            {dynamicRoutes.filter(({ path }) => path === '/').length === 0 && (
+            {ifNotDynamic(
+              '/',
               <Route path="/" element={<HomepageCompositionRoot />}>
                 <HomePage />
               </Route>
             )}
-            <Route path="/catalog" element={<CatalogIndexPage pagination />} />
-            <Route
-              path="/catalog/:namespace/:kind/:name"
-              element={<CatalogEntityPage />}
-            >
-              {entityPage(entityTabOverrides)}
+            {ifNotDynamic(
+              '/catalog',
+              <Route path="/catalog" element={<CatalogIndexPage pagination />} />
+            )}
+            {ifNotDynamic(
+              '//catalog/:namespace/:kind/:name',
+              <Route
+                path="/catalog/:namespace/:kind/:name"
+                element={<CatalogEntityPage />}
+              >
+                {entityPage(entityTabOverrides)}
+              </Route>
+            )}
+            {ifNotDynamic(
+              '/create',
+              <Route
+                path="/create"
+                element={
+                  <ScaffolderPage
+                    headerOptions={{ title: 'Software Templates' }}
+                  />
+                }
+              >
+                <ScaffolderFieldExtensions>
+                  {scaffolderFieldExtensions.map(
+                    ({ scope, module, importName, Component }) => (
+                      <Component key={`${scope}-${module}-${importName}`} />
+                    ),
+                  )}
+                </ScaffolderFieldExtensions>
+                scaffolderFieldExtensions
             </Route>
-            <Route
-              path="/create"
-              element={
-                <ScaffolderPage
-                  headerOptions={{ title: 'Software Templates' }}
-                />
-              }
-            >
-              <ScaffolderFieldExtensions>
-                {scaffolderFieldExtensions.map(
-                  ({ scope, module, importName, Component }) => (
-                    <Component key={`${scope}-${module}-${importName}`} />
-                  ),
-                )}
-              </ScaffolderFieldExtensions>
-              scaffolderFieldExtensions
-            </Route>
-            <Route path="/api-docs" element={<ApiExplorerPage />} />
-            <Route
-              path="/catalog-import"
-              element={
-                <RequirePermission permission={catalogEntityCreatePermission}>
-                  <CatalogImportPage />
-                </RequirePermission>
-              }
-            />
-            <Route path="/search" element={<BackstageSearchPage />}>
-              <SearchPage />
-            </Route>
-            <Route path="/settings" element={<UserSettingsPage />}>
-              {settingsPage}
-            </Route>
-            <Route path="/catalog-graph" element={<CatalogGraphPage />} />
-            <Route path="/learning-paths" element={<LearningPaths />} />
+            )}
+            {ifNotDynamic(
+              '/api-docs',
+              <Route path="/api-docs" element={<ApiExplorerPage />} />
+            )}
+            {ifNotDynamic(
+              '/catalog-import',
+              <Route
+                path="/catalog-import"
+                element={
+                  <RequirePermission permission={catalogEntityCreatePermission}>
+                    <CatalogImportPage />
+                  </RequirePermission>
+                }
+              />
+            )}
+            {ifNotDynamic(
+              '/search',
+              <Route path="/search" element={<BackstageSearchPage />}>
+                <SearchPage />
+              </Route>
+            )}
+            {ifNotDynamic(
+              '/settings',
+              <Route path="/settings" element={<UserSettingsPage />}>
+                {settingsPage}
+              </Route>
+            )}
+            {ifNotDynamic(
+              '/catalog-graph',
+              <Route path="/catalog-graph" element={<CatalogGraphPage />} />
+            )}
+            {ifNotDynamic(
+              '/learning-paths',
+              <Route path="/learning-paths" element={<LearningPaths />} />
+            )}
             <Route path="/admin" element={<AdminPage />} />
             {dynamicRoutes
               .filter(({ path }) => path.startsWith('/admin'))

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -45,11 +45,14 @@ const AppBase = () => {
               '/',
               <Route path="/" element={<HomepageCompositionRoot />}>
                 <HomePage />
-              </Route>
+              </Route>,
             )}
             {ifNotDynamic(
               '/catalog',
-              <Route path="/catalog" element={<CatalogIndexPage pagination />} />
+              <Route
+                path="/catalog"
+                element={<CatalogIndexPage pagination />}
+              />,
             )}
             {ifNotDynamic(
               '//catalog/:namespace/:kind/:name',
@@ -58,7 +61,7 @@ const AppBase = () => {
                 element={<CatalogEntityPage />}
               >
                 {entityPage(entityTabOverrides)}
-              </Route>
+              </Route>,
             )}
             {ifNotDynamic(
               '/create',
@@ -78,11 +81,11 @@ const AppBase = () => {
                   )}
                 </ScaffolderFieldExtensions>
                 scaffolderFieldExtensions
-            </Route>
+              </Route>,
             )}
             {ifNotDynamic(
               '/api-docs',
-              <Route path="/api-docs" element={<ApiExplorerPage />} />
+              <Route path="/api-docs" element={<ApiExplorerPage />} />,
             )}
             {ifNotDynamic(
               '/catalog-import',
@@ -93,27 +96,27 @@ const AppBase = () => {
                     <CatalogImportPage />
                   </RequirePermission>
                 }
-              />
+              />,
             )}
             {ifNotDynamic(
               '/search',
               <Route path="/search" element={<BackstageSearchPage />}>
                 <SearchPage />
-              </Route>
+              </Route>,
             )}
             {ifNotDynamic(
               '/settings',
               <Route path="/settings" element={<UserSettingsPage />}>
                 {settingsPage}
-              </Route>
+              </Route>,
             )}
             {ifNotDynamic(
               '/catalog-graph',
-              <Route path="/catalog-graph" element={<CatalogGraphPage />} />
+              <Route path="/catalog-graph" element={<CatalogGraphPage />} />,
             )}
             {ifNotDynamic(
               '/learning-paths',
-              <Route path="/learning-paths" element={<LearningPaths />} />
+              <Route path="/learning-paths" element={<LearningPaths />} />,
             )}
             <Route path="/admin" element={<AdminPage />} />
             {dynamicRoutes

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -67,22 +67,28 @@ backend.add(dynamicPluginsFrontendSchemas());
 backend.add(customLogger());
 
 backend.add(import('@backstage/plugin-app-backend/alpha'));
-backend.add(
-  import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
-);
 
-backend.add(import('@backstage/plugin-catalog-backend/alpha'));
+if (process.env.DISABLE_STANDARD_CATALOG !== 'true') {
+  backend.add(
+    import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
+  );
+  backend.add(import('@backstage/plugin-catalog-backend/alpha'));
 
-// TODO: Probably we should now provide this as a dynamic plugin
-backend.add(import('@backstage/plugin-catalog-backend-module-openapi'));
+  // TODO: Probably we should now provide this as a dynamic plugin
+  backend.add(import('@backstage/plugin-catalog-backend-module-openapi'));
+}
 
 backend.add(import('@backstage/plugin-proxy-backend/alpha'));
 
-// TODO: Check in the Scaffolder new backend plugin why the identity is not passed and the default is built instead.
-backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
+if (process.env.DISABLE_STANDARD_SCAFFOLDER !== 'true') {
+  // TODO: Check in the Scaffolder new backend plugin why the identity is not passed and the default is built instead.
+  backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
+}
 
-backend.add(import('@backstage/plugin-search-backend/alpha'));
-backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
+if (process.env.DISABLE_STANDARD_SEARCH !== 'true') {
+  backend.add(import('@backstage/plugin-search-backend/alpha'));
+  backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
+}
 
 // TODO: We should test it more deeply. The structure is not exactly the same as the old backend implementation
 backend.add(import('@backstage/plugin-events-backend/alpha'));


### PR DESCRIPTION
## Description

This PR allows  replacing core Backstage features like scaffolder, catalog, or search, in order to customize them.

- For frontend plugins, this is simply done by wiring your own dynamic plugin to a dynamic route with the same path as a standard one (`/` for the home page, or `catalog` for example)
- For backend plugins, before installing your own backend plugin replacement, you first have to disable the standard backend plugins statically linked into the backend application with one of the following environment variables:
  -   DISABLE_STANDARD_CATALOG=true
  -   DISABLE_STANDARD_SCAFFOLDER=true
  -   DISABLE_STANDARD_SEARCH=true

## Which issue(s) does this PR fix

- Fixes issue https://issues.redhat.com/browse/RHIDP-1500

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
