### PR TITLE
chore(docker): set the `NODE_OPTIONS=--no-node-snapshot` env variable

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -167,7 +167,7 @@ ENV TARBALL_PATH=./packages/backend/dist
 RUN tar xzf $TARBALL_PATH/skeleton.tar.gz; tar xzf $TARBALL_PATH/bundle.tar.gz; \
   rm -f $TARBALL_PATH/skeleton.tar.gz $TARBALL_PATH/bundle.tar.gz
 COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
-  
+
 # Copy app-config files needed in runtime
 # Upstream only
 # COPY $EXTERNAL_SOURCE_NESTED/app-config*.yaml ./
@@ -254,6 +254,10 @@ ENV SEGMENT_TEST_MODE=false
 # By setting GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE to an empty value,
 # 'global-agent' will use the same HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
 ENV GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=''
+
+# Enables the usage of the backstage scaffolder on nodejs 20
+# https://github.com/backstage/backstage/issues/20661
+ENV NODE_OPTIONS='--no-node-snapshot'
 
 ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,7 +93,7 @@ ENV TARBALL_PATH=.
 RUN tar xzf $TARBALL_PATH/skeleton.tar.gz; tar xzf $TARBALL_PATH/bundle.tar.gz; \
   rm -f $TARBALL_PATH/skeleton.tar.gz $TARBALL_PATH/bundle.tar.gz
 COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
-  
+
 # Copy app-config files needed in runtime
 # Upstream only
 COPY $EXTERNAL_SOURCE_NESTED/app-config*.yaml ./
@@ -156,6 +156,10 @@ ENV SEGMENT_TEST_MODE=false
 # By setting GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE to an empty value,
 # 'global-agent' will use the same HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
 ENV GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=''
+
+# Enables the usage of the backstage scaffolder on nodejs 20
+# https://github.com/backstage/backstage/issues/20661
+ENV NODE_OPTIONS='--no-node-snapshot'
 
 ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 


### PR DESCRIPTION
## Description

Adds the `NODE_OPTIONS=--no-node-snapshot` env variable so that the scaffolder is usable in nodejs 20.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2436](https://issues.redhat.com/browse/RHIDP-2436)
## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
