### PR TITLE
chore: adding options to keep legacy behavior in export-dynamic script

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-azure-devops-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-azure-devops-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage-community/plugin-azure-devops-backend": "0.6.5"

--- a/dynamic-plugins/wrappers/backstage-plugin-azure-devops/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-azure-devops/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-azure-devops": "0.4.4"

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-bitbucket-cloud --embed-package @backstage/plugin-bitbucket-cloud-common"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-bitbucket-cloud --embed-package @backstage/plugin-bitbucket-cloud-common --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.2.4"

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-bitbucket-server"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-bitbucket-server --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-bitbucket-server": "0.1.31"

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-github --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-github --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-github": "0.6.0"

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-github-org --embed-package @backstage/plugin-catalog-backend-module-github --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-github-org --embed-package @backstage/plugin-catalog-backend-module-github --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-github-org": "0.1.12",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-gitlab": "0.3.15"

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-common": "0.21.7",

--- a/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-dynatrace/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-dynatrace": "10.0.4"

--- a/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-actions/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-github-actions": "0.6.16"

--- a/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-github-issues/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-github-issues": "0.4.2"

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-jenkins-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-jenkins-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage-community/plugin-jenkins-backend": "0.4.5"

--- a/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-jenkins/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-jenkins": "0.9.10"

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-kubernetes-backend --embed-package @backstage/plugin-kubernetes-node --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-kubernetes-backend --embed-package @backstage/plugin-kubernetes-node --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-kubernetes-backend": "0.17.0"

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage/plugin-kubernetes": "0.11.9"

--- a/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-lighthouse/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@mui/icons-material": "5.15.6",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-azure --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-azure --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-azure": "0.1.9"

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-bitbucket-cloud --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-bitbucket-cloud --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.1.7"

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-bitbucket-server --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-bitbucket-server --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.1.7"

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-gerrit --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-gerrit --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-gerrit": "0.1.9"

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-github --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-github --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-github": "0.2.7"

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-gitlab --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-scaffolder-backend-module-gitlab --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/plugin-scaffolder-backend-module-gitlab": "0.3.3"

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-sonarqube-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-sonarqube-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage-community/plugin-sonarqube-backend": "0.2.20"

--- a/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-sonarqube/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage-community/plugin-sonarqube": "0.7.17"

--- a/dynamic-plugins/wrappers/backstage-plugin-tech-radar/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-tech-radar/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage/core-plugin-api": "1.9.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-techdocs-backend @backstage/plugin-search-backend-module-techdocs @backstage/plugin-techdocs-node --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-techdocs-backend @backstage/plugin-search-backend-module-techdocs @backstage/plugin-techdocs-node --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-common": "0.21.7",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@backstage/core-plugin-api": "1.9.2",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @immobiliarelabs/backstage-plugin-gitlab-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @immobiliarelabs/backstage-plugin-gitlab-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-dynamic-feature-service": "0.2.0",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@immobiliarelabs/backstage-plugin-gitlab": "6.5.0"

--- a/dynamic-plugins/wrappers/pagerduty-backstage-plugin/package.json
+++ b/dynamic-plugins/wrappers/pagerduty-backstage-plugin/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@pagerduty/backstage-plugin": "0.12.0"

--- a/dynamic-plugins/wrappers/parfuemerie-douglas-scaffolder-backend-module-azure-repositories/package.json
+++ b/dynamic-plugins/wrappers/parfuemerie-douglas-scaffolder-backend-module-azure-repositories/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @parfuemerie-douglas/scaffolder-backend-module-azure-repositories --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @parfuemerie-douglas/scaffolder-backend-module-azure-repositories --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-common": "0.20.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/backstage-plugin-argo-cd-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/backstage-plugin-argo-cd-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-common": "0.21.7",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-argo-cd": "2.6.5"

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-datadog": "2.2.8"

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-insights/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-github-insights": "2.3.29"

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-github-pull-requests/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-github-pull-requests": "2.5.26"

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-jira": "2.5.8"

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
@@ -17,7 +17,7 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
     "@roadiehq/backstage-plugin-security-insights": "2.3.17"

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-argocd --embed-package @roadiehq/backstage-plugin-argo-cd-backend --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-argocd --embed-package @roadiehq/backstage-plugin-argo-cd-backend --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-common": "0.21.7",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request/dist-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request/dist-dynamic/package.json
@@ -31,9 +31,9 @@
   ],
   "bundleDependencies": true,
   "peerDependencies": {
-    "@backstage/backend-plugin-api": "^0.6.17",
-    "@backstage/plugin-scaffolder-backend": "^1.22.5",
-    "@backstage/plugin-scaffolder-node": "^0.4.3",
+    "@backstage/backend-plugin-api": "0.6.17",
+    "@backstage/plugin-scaffolder-backend": "1.22.5",
+    "@backstage/plugin-scaffolder-node": "0.4.3",
     "@backstage/backend-common": "^0.21.7",
     "@backstage/core-app-api": "^1.12.4",
     "@backstage/core-plugin-api": "^1.9.2"

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-module-http-request --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-module-http-request --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "0.6.17",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
@@ -23,7 +23,7 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-module-utils --override-interop default"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @roadiehq/scaffolder-backend-module-utils --override-interop default --no-embed-as-dependencies"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "0.6.17",


### PR DESCRIPTION
## Description

This is a fix for [RHIDP-2110](https://issues.redhat.com/projects/RHIDP/issues/RHIDP-2110) and [RHIDP-2123](https://issues.redhat.com/projects/RHIDP/issues/RHIDP-2123)

Related PR: https://github.com/janus-idp/backstage-plugins/pull/1729

Please explain the changes you made here.

Adding the option `--no-embed-as-dependencies` for backend plugins and `--in-place` for frontend plugins.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
