### PR TITLE
feat(app) RHIDP-2338 expose dynamic UI config

### DIFF
--- a/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
@@ -5,14 +5,16 @@ import { BackstageApp } from '@backstage/core-app-api';
 import { AnyApiFactory, BackstagePlugin } from '@backstage/core-plugin-api';
 
 import { useThemes } from '@redhat-developer/red-hat-developer-hub-theme';
-import { AppsConfig, getScalprum } from '@scalprum/core';
+import { AppsConfig } from '@scalprum/core';
 import { useScalprum } from '@scalprum/react-core';
 import DynamicRootContext, {
   ComponentRegistry,
   ResolvedDynamicRoute,
   ResolvedMenuItem,
+  EntityTabOverrides,
+  MountPoints,
   RemotePlugins,
-  ScalprumMountPoint,
+  ScaffolderFieldExtension,
   ScalprumMountPointConfig,
 } from './DynamicRootContext';
 import extractDynamicConfig, {
@@ -35,8 +37,6 @@ export type StaticPlugins = Record<
   }
 >;
 
-type EntityTabMap = Record<string, { title: string; mountPoint: string }>;
-
 export const DynamicRoot = ({
   afterInit,
   apis: staticApis,
@@ -57,7 +57,7 @@ export const DynamicRoot = ({
   >(undefined);
   // registry of remote components loaded at bootstrap
   const [components, setComponents] = useState<ComponentRegistry | undefined>();
-  const { initialized, pluginStore } = useScalprum();
+  const { initialized, pluginStore, api: scalprumApi } = useScalprum();
 
   const themes = useThemes();
 
@@ -250,21 +250,20 @@ export const DynamicRoot = ({
       return acc;
     }, []);
 
-    const mountPointComponents = providerMountPoints.reduce<{
-      [mountPoint: string]: ScalprumMountPoint[];
-    }>((acc, entry) => {
-      if (!acc[entry.mountPoint]) {
-        acc[entry.mountPoint] = [];
-      }
-      acc[entry.mountPoint].push({
-        Component: entry.Component,
-        staticJSXContent: entry.staticJSXContent,
-        config: entry.config,
-      });
-      return acc;
-    }, {});
-
-    getScalprum().api.mountPoints = mountPointComponents;
+    const mountPointComponents = providerMountPoints.reduce<MountPoints>(
+      (acc, entry) => {
+        if (!acc[entry.mountPoint]) {
+          acc[entry.mountPoint] = [];
+        }
+        acc[entry.mountPoint].push({
+          Component: entry.Component,
+          staticJSXContent: entry.staticJSXContent,
+          config: entry.config,
+        });
+        return acc;
+      },
+      {},
+    );
 
     const dynamicRoutesComponents = dynamicRoutes.reduce<
       ResolvedDynamicRoute[]
@@ -290,7 +289,6 @@ export const DynamicRoot = ({
           config: route.menuItem.config || {},
         };
       }
-
       const Component =
         allPlugins[route.scope]?.[route.module]?.[route.importName];
       if (Component) {
@@ -316,8 +314,8 @@ export const DynamicRoot = ({
       return acc;
     }, []);
 
-    const entityTabOverrides: EntityTabMap = entityTabs.reduce(
-      (acc: EntityTabMap, { path, title, mountPoint, scope }) => {
+    const entityTabOverrides = entityTabs.reduce<EntityTabOverrides>(
+      (acc, { path, title, mountPoint, scope }) => {
         if (acc[path]) {
           // eslint-disable-next-line no-console
           console.warn(
@@ -328,31 +326,11 @@ export const DynamicRoot = ({
         }
         return acc;
       },
-      {} as EntityTabMap,
+      {},
     );
-    if (!app.current) {
-      app.current = createApp({
-        apis: [...staticApis, ...remoteApis],
-        bindRoutes({ bind }) {
-          bindAppRoutes(bind, resolvedRouteBindingTargets, routeBindings);
-        },
-        icons,
-        plugins: [
-          ...Object.values(staticPluginStore).map(entry => entry.plugin),
-          ...remoteBackstagePlugins,
-        ],
-        themes,
-        components: defaultAppComponents,
-      });
-    }
 
     const scaffolderFieldExtensionComponents = scaffolderFieldExtensions.reduce<
-      {
-        scope: string;
-        module: string;
-        importName: string;
-        Component: React.ComponentType<{}>;
-      }[]
+      ScaffolderFieldExtension[]
     >((acc, { scope, module, importName }) => {
       const extensionComponent = allPlugins[scope]?.[module]?.[importName];
       if (extensionComponent) {
@@ -371,6 +349,31 @@ export const DynamicRoot = ({
       return acc;
     }, []);
 
+    if (!app.current) {
+      app.current = createApp({
+        apis: [...staticApis, ...remoteApis],
+        bindRoutes({ bind }) {
+          bindAppRoutes(bind, resolvedRouteBindingTargets, routeBindings);
+        },
+        icons,
+        plugins: [
+          ...Object.values(staticPluginStore).map(entry => entry.plugin),
+          ...remoteBackstagePlugins,
+        ],
+        themes,
+        components: defaultAppComponents,
+      });
+    }
+
+    // make the dynamic UI configuration available via Scalprum if possible
+    const dynamicRootConfig = scalprumApi ? scalprumApi.dynamicRootConfig : {};
+    dynamicRootConfig.dynamicRoutes = dynamicRoutesComponents;
+    dynamicRootConfig.entityTabOverrides = entityTabOverrides;
+    dynamicRootConfig.mountPoints = mountPointComponents;
+    dynamicRootConfig.scaffolderFieldExtensions =
+      scaffolderFieldExtensionComponents;
+
+    // make the dynamic UI configuration available to DynamicRootContext consumers
     setComponents({
       AppProvider: app.current.getProvider(),
       AppRouter: app.current.getRouter(),
@@ -385,6 +388,7 @@ export const DynamicRoot = ({
     });
   }, [
     afterInit,
+    scalprumApi,
     dynamicPlugins,
     pluginStore,
     scalprumConfig,

--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -27,6 +27,7 @@ export type DynamicModuleEntry = Pick<
   ScalprumComponentProps,
   'scope' | 'module'
 >;
+
 export type ResolvedDynamicRoute = DynamicModuleEntry & {
   path: string;
   menuItem?: ResolvedMenuItem;
@@ -81,19 +82,31 @@ export type RemotePlugins = {
   };
 };
 
+export type EntityTabOverrides = Record<
+  string,
+  { title: string; mountPoint: string }
+>;
+
+export type MountPoints = Record<string, ScalprumMountPoint[]>;
+
+export type ScaffolderFieldExtension = {
+  scope: string;
+  module: string;
+  importName: string;
+  Component: React.ComponentType<{}>;
+};
+
+export type DynamicRootConfig = {
+  dynamicRoutes: ResolvedDynamicRoute[];
+  entityTabOverrides: EntityTabOverrides;
+  mountPoints: MountPoints;
+  scaffolderFieldExtensions: ScaffolderFieldExtension[];
+};
+
 export type ComponentRegistry = {
   AppProvider: React.ComponentType<React.PropsWithChildren>;
   AppRouter: React.ComponentType<React.PropsWithChildren>;
-  dynamicRoutes: ResolvedDynamicRoute[];
-  entityTabOverrides: Record<string, { title: string; mountPoint: string }>;
-  mountPoints: { [mountPoint: string]: ScalprumMountPoint[] };
-  scaffolderFieldExtensions: {
-    scope: string;
-    module: string;
-    importName: string;
-    Component: React.ComponentType<{}>;
-  }[];
-};
+} & DynamicRootConfig;
 
 const DynamicRootContext = createContext<ComponentRegistry>({
   AppProvider: () => null,

--- a/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
@@ -13,6 +13,11 @@ import Loader from './Loader';
 import { AppConfig } from '@backstage/config';
 import { DynamicRoot, StaticPlugins } from './DynamicRoot';
 import { DynamicPluginConfig } from '../../utils/dynamicUI/extractDynamicConfig';
+import { DynamicRootConfig } from './DynamicRootContext';
+
+export type ScalprumApiHolder = {
+  dynamicRootConfig: DynamicRootConfig;
+};
 
 const ScalprumRoot = ({
   apis,
@@ -65,8 +70,17 @@ const ScalprumRoot = ({
     return <Loader />;
   }
   const { dynamicPlugins, baseUrl, scalprumConfig } = value || {};
+  const scalprumApiHolder = {
+    dynamicRootConfig: {
+      dynamicRoutes: [],
+      entityTabOverrides: {},
+      mountPoints: {},
+      scaffolderFieldExtensions: [],
+    } as DynamicRootConfig,
+  };
   return (
-    <ScalprumProvider
+    <ScalprumProvider<ScalprumApiHolder>
+      api={scalprumApiHolder}
       config={scalprumConfig ?? {}}
       pluginSDKOptions={{
         pluginLoaderOptions: {

--- a/packages/app/src/utils/dynamicUI/getMountPointData.ts
+++ b/packages/app/src/utils/dynamicUI/getMountPointData.ts
@@ -8,7 +8,7 @@ function getMountPointData<T = any, T2 = any>(
   Component: T;
   staticJSXContent: T2;
 }[] {
-  return getScalprum().api.mountPoints?.[mountPoint] ?? [];
+  return getScalprum().api.dynamicRootConfig?.mountPoints?.[mountPoint] ?? [];
 }
 
 export default getMountPointData;


### PR DESCRIPTION
Please explain the changes you made here.

This change exposes the dynamic UI configuration to dynamic plugins via
the scalprum API holder available with the scalprum React API.  This
change also moves around some blocks for consistency and improves the
typing for the DynamicRootContext objects.

- Fixes [RHIDP-2338](https://issues.redhat.com/browse/RHIDP-2338)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

This can be validated using [this plugin](https://github.com/gashcrumb/simple-test-components) which contains a component that will use the configuration exposed via scalprum to create a new mount point, and then render a component on that mount point.  Use this configuration:

```yaml
    backstage-plugin-simple-test-components:
      dynamicRoutes:
        - path: /test-route
          importName: CustomSearchPage
          menuItem:
            text: Search2
      mountPoints:
        - mountPoint: custom.mount.point
          importName: SimpleTestComponentsPage
          config:
            props:
              text: 'Content Block in a custom mount point'
```