### PR TITLE
feat: support catalog entity extra context menu items.

### DIFF
--- a/packages/app/src/components/catalog/EntityPage/ContextMenuAwareEntityLayout.tsx
+++ b/packages/app/src/components/catalog/EntityPage/ContextMenuAwareEntityLayout.tsx
@@ -1,0 +1,52 @@
+import React, { ReactNode, useMemo, useState } from 'react';
+import { EntityLayout } from '@backstage/plugin-catalog';
+import getMountPointData from '../../../utils/dynamicUI/getMountPointData';
+import { MenuIcon } from '../../Root/Root';
+
+export const ContextMenuAwareEntityLayout = (props: {
+  children?: ReactNode;
+}) => {
+  const contextMenuElements =
+    getMountPointData<React.ComponentType<React.PropsWithChildren<any>>>(
+      `entity.context.menu`,
+    );
+
+  const [openStates, openStatesSet] = useState(
+    new Array<boolean>(contextMenuElements.length).fill(false),
+  );
+
+  const extraMenuItems = useMemo(
+    () =>
+      contextMenuElements.map((e, index) => ({
+        title: e.config.props?.title ?? 'title',
+        Icon: () => <MenuIcon icon={e.config.props?.icon ?? 'icon'} />,
+        onClick: () => {
+          openStatesSet(openStates.map((s, i) => (i === index ? true : s)));
+        },
+      })),
+    [contextMenuElements, openStates],
+  );
+
+  return (
+    <>
+      <EntityLayout
+        UNSTABLE_extraContextMenuItems={extraMenuItems}
+        UNSTABLE_contextMenuOptions={{
+          disableUnregister: 'visible',
+        }}
+      >
+        {props.children}
+      </EntityLayout>
+      {contextMenuElements.map(({ Component }, index) => (
+        <>
+          <Component
+            open={openStates[index]}
+            onClose={() =>
+              openStatesSet(openStates.map((s, i) => (i === index ? false : s)))
+            }
+          />
+        </>
+      ))}
+    </>
+  );
+};

--- a/packages/app/src/components/catalog/EntityPage/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage/EntityPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { EntityLayout } from '@backstage/plugin-catalog';
 import { dynamicEntityTab, DynamicEntityTabProps } from './DynamicEntityTab';
 import { defaultTabs, tabRules, tabChildren } from './defaultTabs';
+import { ContextMenuAwareEntityLayout } from './ContextMenuAwareEntityLayout';
 
 /**
  * Displays the tabs and content for a catalog entity
@@ -16,7 +16,7 @@ export const entityPage = (
   > = {},
 ) => {
   return (
-    <EntityLayout>
+    <ContextMenuAwareEntityLayout>
       {Object.entries({ ...defaultTabs, ...entityTabOverrides }).map(
         ([path, config]) => {
           return dynamicEntityTab({
@@ -27,6 +27,6 @@ export const entityPage = (
           } as DynamicEntityTabProps);
         },
       )}
-    </EntityLayout>
+    </ContextMenuAwareEntityLayout>
   );
 };


### PR DESCRIPTION
## Description

This PR adds support for dynamic frontend plugins that contribute extra items in the Catalog entity package content menu.
 
Without this support, plugins like the upstream `badges` or `playlist` plugins cannot be used as dynamic plugins.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2530](https://issues.redhat.com/browse/RHIDP-2530)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
