### PR TITLE
chore(deps): update topology plugin

### DIFF
--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -28,7 +28,7 @@
     "@janus-idp/backstage-plugin-quay": "1.7.8",
     "@janus-idp/backstage-plugin-rbac": "1.20.14",
     "@janus-idp/backstage-plugin-tekton": "3.7.7",
-    "@janus-idp/backstage-plugin-topology": "1.21.9",
+    "@janus-idp/backstage-plugin-topology": "1.21.10",
     "@janus-idp/backstage-plugin-argocd": "1.1.8",
     "@janus-idp/backstage-scaffolder-backend-module-quay": "1.4.12",
     "@janus-idp/backstage-scaffolder-backend-module-regex": "1.4.12",


### PR DESCRIPTION
## Description

Updates the topology plugin to `1.21.10`. `1.21.10` fixes a bug where conditional permission policies for catalog entities would cause the topology view to now show up. 

## Which issue(s) does this PR fix

- Fixes [RHIDP-2594](https://issues.redhat.com/browse/RHIDP-2594)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
