### PR TITLE
fix(auth): fix deprecation warning when OIDC provider is configured

### DIFF
--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -47,6 +47,7 @@ export const apis: AnyApiFactory[] = [
     },
     factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
       OAuth2.create({
+        configApi,
         discoveryApi,
         oauthRequestApi,
         provider: {


### PR DESCRIPTION
## Description
Passes the expected `configApi` parameter to resolve warning.

## Which issue(s) does this PR fix
- Fixes [RHIDP-2627](https://issues.redhat.com/browse/RHIDP-2627)

## PR acceptance criteria
Deprecation warning is not present in the browser console when the OIDC provider is configured.

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related