### PR TITLE
feat: tagRelease.sh bump versions in 1.2.x for 1.2 release

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showcase-app",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Showcase E2E test",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/packages/app/src/build-metadata.json
+++ b/packages/app/src/build-metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "RHDH Metadata",
   "card": [
-    "RHDH Version: 1.2.0",
+    "RHDH Version: 1.2.1",
     "Backstage Version: 1.26.5",
     "Last Commit: repo @ 2024-05-10T14:59:23Z"
   ]


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
