### PR TITLE
[e2e] Increase Plawright resolution to 1080p

### DIFF
--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -55,7 +55,8 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1920, height: 1080 },
-      },      testMatch: [
+      },
+      testMatch: [
         '**/playwright/e2e/plugins/rbac/**/*.spec.ts',
         '**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts',
         '**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts',

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: {
       mode: 'on',
-      size: { width: 1280, height: 720 },
+      size: { width: 1920, height: 1080 },
     },
   },
 
@@ -40,7 +40,10 @@ export default defineConfig({
   projects: [
     {
       name: 'showcase',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+      },
       testIgnore: [
         '**/playwright/e2e/plugins/rbac/**/*.spec.ts',
         '**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts',
@@ -49,8 +52,10 @@ export default defineConfig({
     },
     {
       name: 'showcase-rbac',
-      use: { ...devices['Desktop Chrome'] },
-      testMatch: [
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+      },      testMatch: [
         '**/playwright/e2e/plugins/rbac/**/*.spec.ts',
         '**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts',
         '**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts',

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -171,7 +171,7 @@ export async function setupBrowser(browser: Browser, testInfo: TestInfo) {
       dir: `test-results/${path
         .parse(testInfo.file)
         .name.replace('.spec', '')}`,
-      size: { width: 1280, height: 720 },
+      size: { width: 1920, height: 1080 },
     },
   });
   const page = await context.newPage();


### PR DESCRIPTION
## Description

Now we are using the default resolution for tests 720p. I suggest to switch to 1080p for two reasons:
- Users probably use 1080p (minimum)
- Some parts of the UI might not be shown at 720p (see the two screenshots) bellow.

The drawback is, that the screen recordings will be slightly bigger.

720p
![720p](https://github.com/janus-idp/backstage-showcase/assets/61500440/458872a9-a56f-4a9b-ab5b-a8f84a1ac185)

1080p
![1080p](https://github.com/janus-idp/backstage-showcase/assets/61500440/a093252b-3f8c-4c5b-a6e6-39eca9ee53db)


## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
