### PR TITLE
chore(docker): remove NODE_OPTIONS in favor of embedding it into the ENTRYPOINT

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -255,10 +255,9 @@ ENV SEGMENT_TEST_MODE=false
 # 'global-agent' will use the same HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
 ENV GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=''
 
-# Enables the usage of the backstage scaffolder on nodejs 20
+# The `--no-node-snapshot` node option enables the usage of the backstage scaffolder on nodejs 20
 # https://github.com/backstage/backstage/issues/20661
-ENV NODE_OPTIONS='--no-node-snapshot'
 
-ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
+ENTRYPOINT ["node", "packages/backend", "--no-node-snapshot", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -157,10 +157,9 @@ ENV SEGMENT_TEST_MODE=false
 # 'global-agent' will use the same HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.
 ENV GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=''
 
-# Enables the usage of the backstage scaffolder on nodejs 20
+# The `--no-node-snapshot` node option enables the usage of the backstage scaffolder on nodejs 20
 # https://github.com/backstage/backstage/issues/20661
-ENV NODE_OPTIONS='--no-node-snapshot'
 
-ENTRYPOINT ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
+ENTRYPOINT ["node", "packages/backend", "--no-node-snapshot", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here


### PR DESCRIPTION
## Description

Update the docker file to remove the `NODE_OPTIONS=--no-node-snapshot` environmental variable in favor of directly adding it as an argument in the `ENTRYPOINT`.

This allows users to define their own `NODE_OPTIONS` to add additional node arguments (such as `--max-http-header-size=32768`) without accidentally overwriting the existing `NODE_OPTIONS` defined in the image.
## Which issue(s) does this PR fix

- Fixes N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
