### PR TITLE
bump keycloak-backend plugin version

### DIFF
--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -21,7 +21,7 @@
     "@janus-idp/backstage-plugin-acr": "1.5.0",
     "@janus-idp/backstage-plugin-analytics-provider-segment": "1.5.0",
     "@janus-idp/backstage-plugin-jfrog-artifactory": "1.5.0",
-    "@janus-idp/backstage-plugin-keycloak-backend": "1.10.0",
+    "@janus-idp/backstage-plugin-keycloak-backend": "1.11.1",
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.7.0",
     "@janus-idp/backstage-plugin-ocm": "4.2.0",
     "@janus-idp/backstage-plugin-ocm-backend": "4.1.0",


### PR DESCRIPTION
## Description

Bump the keycloak-backend plugin version to `1.11.1` to include the "[expose extension points for the keycloak-backend plugin](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/keycloak-backend/CHANGELOG.md#janus-idpbackstage-plugin-keycloak-backend-1110-2024-06-19)" change.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2965](https://issues.redhat.com/browse/RHIDP-2965)

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related
