### PR TITLE
RHIDP-3248: fix(learningpath): restore spacing between cards

### DIFF
--- a/packages/app/src/components/learningPaths/LearningPathsPage.tsx
+++ b/packages/app/src/components/learningPaths/LearningPathsPage.tsx
@@ -14,9 +14,6 @@ import {
 } from '../../hooks/useCustomizationData';
 
 const useStyles = makeStyles()({
-  link: {
-    textDecoration: 'none',
-  },
   infoCard: {
     height: '100%',
     transition: 'all 0.25s linear',
@@ -67,21 +64,19 @@ const LearningPathCards = () => {
 
   return (
     <Grid container justifyContent="center" alignContent="center" spacing={2}>
-      <Grid item xs={12} container justifyContent="center">
-        {data.map(p => (
-          <Grid item xs={12} sm={6} md={4} lg={3} xl={3} key={p.label}>
-            <Link href={p.url} className={classes.link} target="_blank">
-              <InfoCard
-                className={classes.infoCard}
-                title={p.label}
-                subheader={learningPathLengthInfo(p)}
-              >
-                <Typography paragraph>{p.description}</Typography>
-              </InfoCard>
-            </Link>
-          </Grid>
-        ))}
-      </Grid>
+      {data.map(p => (
+        <Grid item xs={12} sm={6} md={4} lg={3} xl={3} key={p.label}>
+          <Link href={p.url} target="_blank" underline="none">
+            <InfoCard
+              className={classes.infoCard}
+              title={p.label}
+              subheader={learningPathLengthInfo(p)}
+            >
+              <Typography paragraph>{p.description}</Typography>
+            </InfoCard>
+          </Link>
+        </Grid>
+      ))}
     </Grid>
   );
 };
@@ -89,11 +84,11 @@ const LearningPathCards = () => {
 export const LearningPaths = () => {
   return (
     <SearchContextProvider>
-      <Page themeId="home">
+      <Page themeId="learningpaths">
         <Header title="Learning Paths" />
         <Content>
-          <Grid container justifyContent="center" spacing={6}>
-            <Grid item xs={12}>
+          <Grid container justifyContent="center">
+            <Grid item>
               <LearningPathCards />
             </Grid>
           </Grid>


### PR DESCRIPTION
## Description

Fixes: https://issues.redhat.com/browse/RHIDP-3248

With #1379 the @mui/material package is updated from 5.15.21 to 5.16.0 which breaks the learning path page.

* Removed an extra layer of Grid that wasn't necessary.
* Also replaced the custom CSS rule `textDecoration: 'none'` with a Link prop `.underline="none"`

Some history:

### 1.0.0

![1 0 0](https://github.com/user-attachments/assets/5b632c20-f9c6-4a25-bf71-ab7e19fb4c7e)

### 1.1.0

![1 1 0](https://github.com/user-attachments/assets/f8374a2e-75c6-4cf0-8a92-4626aef87a87)

### 1.2.0 branch (close to 1.2.2 release)

![1 2-branch](https://github.com/user-attachments/assets/54c777d9-79b0-495a-813b-812793f0dc07)

### main branch (without latest theme, theme )

![main](https://github.com/user-attachments/assets/d83f60e3-6fb3-45f0-beb4-a9e5448d48ac)

### update-theme branch (with theme 0.1.7)

![image](https://github.com/user-attachments/assets/8a04c613-bee0-4ad1-afd8-63935af08598)

### With this change on main

![with-pr](https://github.com/user-attachments/assets/b91e5164-4e13-4e88-b9d2-d3fe85d97767)

### With this change on update-theme

![image](https://github.com/user-attachments/assets/857a128e-e852-4364-a7ad-efc0b6d45baa)

## Which issue(s) does this PR fix

- Fixes TODO

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
