### PR TITLE
add dangerouslySignInWithoutUserInCatalog option

### DIFF
--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -124,4 +124,9 @@ export interface Config {
    * @visibility frontend
    */
   signInPage?: string;
+  /**
+   * The option to allow sign in without existing user in the catalog, defaults to false
+   * @visibility frontend
+   */
+  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
 }

--- a/showcase-docs/auth.md
+++ b/showcase-docs/auth.md
@@ -177,3 +177,13 @@ The guest login is provided by a special authentication provider that must be ex
   ```
 
 - To disable the guest login set `auth.environment` to `production`.
+
+### dangerouslyAllowSignInWithoutUserInCatalog configuration value
+
+This option allows users to sign in even if their profile has not been ingested into the catalog. By default, this option is set to false. Enabling this option is dangerous as it may allow unauthorized users to gain access.
+
+To enable this option:
+
+```yaml
+dangerouslyAllowSignInWithoutUserInCatalog: true
+```


### PR DESCRIPTION
## Description
Update the `signInWithCatalogUserOptional` option to only allow sign in without user being in the catalog with the config `dangerouslySignInWithoutUserInCatalog: true`.

## Which issue(s) does this PR fix

- Fixes [RHIDP-3074](https://issues.redhat.com/browse/RHIDP-3074)

## PR acceptance criteria
1. Try to sign in with user not present in the catalog and you should see the error message appear - not allowing sign in 
2. Add config: `dangerouslySignInWithoutUserInCatalog: true` and verify that the error message no longer appears and sign in is successful

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related