### PR TITLE
ensure that images contain only the minimum set of dependencies

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -190,7 +190,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Downstream only - install techdocs dependencies using cachito sources
 COPY $REMOTE_SOURCES/upstream2 $REMOTE_SOURCES_DIR/upstream2/
 # hadolint ignore=DL3013,DL3041,SC2086
-RUN microdnf update –setopt=install_weak_deps=0 -y && \
+RUN microdnf update --setopt=install_weak_deps=0 -y && \
   microdnf install -y python3.11 python3.11-pip python3.11-devel make cmake cpp gcc gcc-c++; \
   ln -s /usr/bin/pip3.11 /usr/bin/pip3; \
   ln -s /usr/bin/pip3.11 /usr/bin/pip; \

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -190,7 +190,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Downstream only - install techdocs dependencies using cachito sources
 COPY $REMOTE_SOURCES/upstream2 $REMOTE_SOURCES_DIR/upstream2/
 # hadolint ignore=DL3013,DL3041,SC2086
-RUN microdnf update -y && \
+RUN microdnf update –setopt=install_weak_deps=0 -y && \
   microdnf install -y python3.11 python3.11-pip python3.11-devel make cmake cpp gcc gcc-c++; \
   ln -s /usr/bin/pip3.11 /usr/bin/pip3; \
   ln -s /usr/bin/pip3.11 /usr/bin/pip; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Upstream only - install techdocs dependencies (PyPI source tarballs not required)
 # When updating version of mkdocs-techdocs-core remember to update ../.rhdh/docker/requirement* files too
 # hadolint ignore=DL3041,DL3042
-RUN microdnf update –setopt=install_weak_deps=0 -y && \
+RUN microdnf update --setopt=install_weak_deps=0 -y && \
   microdnf install -y python3 python3-pip && \
   pip3 install mkdocs-techdocs-core~=1.3.3 && \
   microdnf clean all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Upstream only - install techdocs dependencies (PyPI source tarballs not required)
 # When updating version of mkdocs-techdocs-core remember to update ../.rhdh/docker/requirement* files too
 # hadolint ignore=DL3041,DL3042
-RUN microdnf update -y && \
+RUN microdnf update –setopt=install_weak_deps=0 -y && \
   microdnf install -y python3 python3-pip && \
   pip3 install mkdocs-techdocs-core~=1.3.3 && \
   microdnf clean all


### PR DESCRIPTION
## Description

Specified `--setopt=install_weak_deps=0` to ensure we are only pulling in required packages when we run a "microdnf update" in the Dockerfiles. 

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-3213 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
