### PR TITLE
Enable dangerouslyAllowSignInWithoutUserInCatalog option for GitHub

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -30,11 +30,13 @@ import { ConfigSources } from '@backstage/config-loader';
  *
  * @param name
  * @param ctx
+ * @param enableDangerouslyAllowSignInWithoutUserInCatalog
  * @returns
  */
 async function signInWithCatalogUserOptional(
   name: string,
   ctx: AuthResolverContext,
+  enableDangerouslyAllowSignInWithoutUserInCatalog?: boolean,
 ) {
   try {
     const signedInUser = await ctx.signInWithCatalogUser({
@@ -48,6 +50,7 @@ async function signInWithCatalogUserOptional(
     );
     const dangerouslyAllowSignInWithoutUserInCatalog =
       config.getOptionalBoolean('dangerouslyAllowSignInWithoutUserInCatalog') ||
+      enableDangerouslyAllowSignInWithoutUserInCatalog ||
       false;
     if (!dangerouslyAllowSignInWithoutUserInCatalog) {
       throw new Error(
@@ -149,7 +152,8 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
                 `GitHub user profile does not contain a username`,
               );
             }
-            return await signInWithCatalogUserOptional(userId, ctx);
+            // enable dangerouslyAllowSignInWithoutUserInCatalog option temporarily for GitHub
+            return await signInWithCatalogUserOptional(userId, ctx, true);
           },
         },
       });


### PR DESCRIPTION
## Description

[This issue](https://issues.redhat.com/browse/RHIDP-3529) with GitHub user entities not being ingested into the catalog as expected causes the error when trying to sign in with Github in some environments. Temporarily enabling this setting for GitHub until this issue is resolved. (More details in the Jira issue)

## Which issue(s) does this PR fix

- Related to [RHIDP-3529](https://issues.redhat.com/browse/RHIDP-3529)

## PR acceptance criteria
Confirm that the error not longer appears when signing in with GitHub and the user does not exist in the catalog.

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related