### PR TITLE
WIP feat: add support for plugins packaged in oci images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -120,7 +120,7 @@ WORKDIR $CONTAINER_SOURCE/
 # hadolint ignore=DL3041,DL3042
 RUN microdnf update --setopt=install_weak_deps=0 -y && \
   microdnf install -y python3 python3-pip && \
-  pip3 install mkdocs-techdocs-core~=1.3.3 && \
+  pip3 install mkdocs-techdocs-core~=1.3.3 oras~=0.1.30 && \
   microdnf clean all
 
 # Upstream only - copy from cleanup stage


### PR DESCRIPTION
## Description
Adds support for loading plugins packaged inside OCI images


config example
```yaml
    plugins:
      - disabled: false
        package: >-
          oci://quay.io/tkral/simple-chat:v0.0.1!internal-backstage-plugin-simple-chat-backend-dynamic
      - disabled: false
        package: >-
          oci://quay.io/tkral/simple-chat:v0.0.1!internal-backstage-plugin-simple-chat
        pluginConfig:
          dynamicPlugins:
            frontend:
              internal.backstage-plugin-simple-chat:
                appIcons:
                  - importName: ChatIcon
                    name: chatIcon
                dynamicRoutes:
                  - importName: SimpleChatPage
                    menuItem:
                      icon: chatIcon
                      text: Simple Chat
                    path: /simple-chat
```

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
