### PR TITLE
fix(ui): remove default sign in provider

### DIFF
--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
@@ -11,6 +11,7 @@ data:
       auth:
         keys:
           - secret: temp
+    signInPage: github
     integrations:
       # Plugin: GitHub
       github:

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -25,6 +25,7 @@ data:
       auth:
         keys:
           - secret: temp
+    signInPage: github
     integrations:
       # Plugin: GitHub
       github:

--- a/packages/app/src/components/SignInPage/SignInPage.tsx
+++ b/packages/app/src/components/SignInPage/SignInPage.tsx
@@ -22,8 +22,6 @@ import {
 } from '@backstage/core-components';
 import { auth0AuthApiRef, oidcAuthApiRef, samlAuthApiRef } from '../../api';
 
-const DEFAULT_PROVIDER = 'github';
-
 /**
  * Key:
  * string - Provider name.
@@ -150,10 +148,8 @@ const PROVIDERS = new Map<string, SignInProviderConfig | string>([
 export function SignInPage(props: SignInPageProps): React.JSX.Element {
   const configApi = useApi(configApiRef);
   const isDevEnv = configApi.getString('auth.environment') === 'development';
-  const provider =
-    configApi.getOptionalString('signInPage') ?? DEFAULT_PROVIDER;
-  const providerConfig =
-    PROVIDERS.get(provider) ?? PROVIDERS.get(DEFAULT_PROVIDER)!;
+  const provider = configApi.getOptionalString('signInPage') ?? '';
+  const providerConfig = PROVIDERS.get(provider) ?? '';
 
   if (typeof providerConfig === 'object') {
     const providers = isDevEnv
@@ -166,6 +162,17 @@ export function SignInPage(props: SignInPageProps): React.JSX.Element {
         title="Select a sign-in method"
         align="center"
         providers={providers}
+      />
+    );
+  }
+
+  if (provider === '') {
+    return (
+      <CCSignInPage
+        {...props}
+        title="Select a sign-in method"
+        align="center"
+        providers={['guest']}
       />
     );
   }


### PR DESCRIPTION
## Description

The GitHub Sign In card is always shown regardless of the auth configuration in backstage, giving the impression to the user that it is possible to login to GitHub as an alternative method. However, when clicking the link, a popup is opened with a JSON error.

## Which issue(s) does this PR fix

- Fixes [RHIDP-2398](https://issues.redhat.com/browse/RHIDP-2398)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Default Sign In page without setting optional `signInPage` value in `app-config`.
![image](https://github.com/user-attachments/assets/e3ed5efe-6ea6-48a1-9606-ef5ca224cb05)

