### PR TITLE
feat(ui): configurable and customizable main navigation

### DIFF
--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
@@ -7,6 +7,40 @@ data:
   app-config-rhdh.yaml: |
     app:
       title: Red Hat Developer Hub
+      mainMenu:
+        defaultItems:
+        - title: Search
+          path: '/search'
+          icon: search
+        - title: Home
+          path: '/'
+          icon: home_outlined
+        - title: Catalog
+          path: '/catalog'
+          icon: category_outlined
+        - title: APIs
+          path: '/api-docs'
+          icon: extension_outlined
+        - title: Learning Paths
+          path: '/learning-paths'
+          icon: school_outlined
+        - title: Create...
+          path: '/create'
+          icon: add_circle_outlined
+        - title: settings
+          path: '/settings'
+          icon: account_circle_outlined
+        extraItems:
+        - title: Administration
+          name: admin
+          icon: gpp_maybe_outlined
+          subMenuItems:
+          - title: RBAC
+            key: rbac
+            icon: vpn_key_outlined
+          - title: Plugins
+            key: plugins
+            icon: power_outlined
     backend:
       auth:
         keys:

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -21,6 +21,40 @@ data:
             headerColor1: 'rgb(0, 0, 208)'
             headerColor2: 'rgb(255, 246, 140)'
             navigationIndicatorColor: 'rgb(244, 238, 169)'
+      mainMenu:
+        defaultItems:
+        - title: Search
+          path: '/search'
+          icon: search
+        - title: Home
+          path: '/'
+          icon: home_outlined
+        - title: Catalog
+          path: '/catalog'
+          icon: category_outlined
+        - title: APIs
+          path: '/api-docs'
+          icon: extension_outlined
+        - title: Learning Paths
+          path: '/learning-paths'
+          icon: school_outlined
+        - title: Create...
+          path: '/create'
+          icon: add_circle_outlined
+        - title: settings
+          path: '/settings'
+          icon: account_circle_outlined
+        extraItems:
+        - title: Administration
+          name: admin
+          icon: gpp_maybe_outlined
+          subMenuItems:
+          - title: RBAC
+            key: rbac
+            icon: vpn_key_outlined
+          - title: Plugins
+            key: plugins
+            icon: power_outlined
     backend:
       auth:
         keys:

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -32,6 +32,27 @@ export interface Config {
         [key: string]: unknown;
       };
     };
+    mainMenu?: {
+      /** @deepVisibility frontend */
+      defaultItems?: {
+        /** @deepVisibility frontend */
+        title: string;
+        path: string;
+        icon: string;
+      }[];
+      /** @deepVisibility frontend */
+      extraItems?: {
+        title: string;
+        name: string;
+        icon: string;
+        /** @deepVisibility frontend */
+        subMenuItems?: {
+          title: string;
+          key: string;
+          icon: string;
+        }[];
+      }[];
+    };
   };
   /** @deepVisibility frontend */
   dynamicPlugins: {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,6 +42,7 @@
     "@mui/icons-material": "5.16.4",
     "@mui/material": "5.16.4",
     "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
+    "material-icons": "1.13.12",
     "@scalprum/core": "0.7.0",
     "@scalprum/react-core": "0.8.0",
     "lodash": "4.17.21",

--- a/packages/app/src/bootstrap.tsx
+++ b/packages/app/src/bootstrap.tsx
@@ -1,3 +1,4 @@
+import 'material-icons/iconfont/material-icons.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/packages/app/src/components/DynamicRoot/index.ts
+++ b/packages/app/src/components/DynamicRoot/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ScalprumRoot';
+export { DynamicRoot } from './DynamicRoot';

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -20,10 +20,10 @@ import {
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
-import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { Config } from '@backstage/config';
 import MuiIcon from '@mui/material/Icon';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
 const listItemComponent = (
   icon: any,
@@ -123,12 +123,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
     (openNestedMenuItems: boolean, handleClickItem: () => void) => {
       const renderExpandIcon = (openDropdownMenu: boolean) => {
         return openDropdownMenu ? (
-          <ExpandLess
+          <ExpandMore
             fontSize="small"
             style={{ display: 'flex', marginLeft: '0.5rem' }}
           />
         ) : (
-          <ExpandMore
+          <ChevronRightIcon
             fontSize="small"
             style={{ display: 'flex', marginLeft: '0.5rem' }}
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -23381,6 +23381,11 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+material-icons@1.13.12:
+  version "1.13.12"
+  resolved "https://registry.npmjs.org/material-icons/-/material-icons-1.13.12.tgz#eed4082bf0426642edeb027e75397e3064adc536"
+  integrity sha512-/2YoaB79IjUK2B2JB+vIXXYGtBfHb/XG66LvoKVM5ykHW7yfrV5SP6d7KLX6iijY6/G9GqwgtPQ/sbhFnOURVA==
+
 material-ui-popup-state@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/material-ui-popup-state/-/material-ui-popup-state-1.9.3.tgz#133ee02be8adf936e738d6b5f3dc89726af39bce"


### PR DESCRIPTION
## Description

Implement a configurable and customizable main navigation sidebar in RHDH

## Which issue(s) does this PR fix

- Fixes [RHIDP-3064](https://issues.redhat.com/browse/RHIDP-3064)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

app-config spinnet for testing:
```
app:
  mainMenu:
    defaultItems:
    - title: Search
      path: '/search'
      icon: search
    - title: Home
      path: '/'
      icon: home_outlined
    - title: Catalog
      path: '/catalog'
      icon: category_outlined
    - title: APIs
      path: '/api-docs'
      icon: extension_outlined
    - title: Learning Paths
      path: '/learning-paths'
      icon: school_outlined
    - title: Create...
      path: '/create'
      icon: add_circle_outlined
    - title: settings
      path: '/settings'
      icon: account_circle_outlined
    extraItems:
    - title: Administration
      name: admin
      icon: gpp_maybe_outlined
      subMenuItems:
      - title: RBAC
        key: rbac
        icon: vpn_key_outlined
      - title: Plugins
        key: plugins
        icon: power_outlined
```

Screen recording(updated on 8/14):


https://github.com/user-attachments/assets/12268f45-c5c1-44d4-a851-50942a80ded9




