### PR TITLE
chore: regen yarn.lock to remove name property

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/dist-dynamic/yarn.lock
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/dist-dynamic/yarn.lock
@@ -674,7 +674,6 @@
     tslib "^2.6.2"
 
 "@aws-sdk/util-utf8-browser@npm:@smithy/util-utf8@~2", "@smithy/util-utf8@^2.0.0":
-  name "@aws-sdk/util-utf8-browser"
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
   integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==


### PR DESCRIPTION
## Description

Please explain the changes you made here.
Making this consistent with 1.2.x.  Name property got generated as a result of [PR](https://github.com/janus-idp/backstage-showcase/pull/1462) but it may conflict with resolved package, so I'm removing it just to err on the side of caution

## Which issue(s) does this PR fix

- Fixes #?
- N/A

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
