### PR TITLE
chore(yarn): switch to use Yarn v1 in...

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/dist-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/dist-dynamic/package.json
@@ -47,7 +47,6 @@
     "support:tech-preview",
     "lifecycle:active"
   ],
-  "packageManager": "yarn@1.22.22",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-plugin-api": "^0.7.0",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/dist-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/dist-dynamic/package.json
@@ -47,7 +47,7 @@
     "support:tech-preview",
     "lifecycle:active"
   ],
-  "packageManager": "yarn@3.8.1+sha512.8cfec856814c797ccb480703ca5270824327fac5abce240835e2699e01732229fd22bbeb1bb87047a0069f7698be9b2e3d9a926e6046e851faa9908fdacdeacf",
+  "packageManager": "yarn@1.22.22",
   "bundleDependencies": true,
   "peerDependencies": {
     "@backstage/backend-plugin-api": "^0.7.0",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
@@ -55,5 +55,5 @@
     "support:tech-preview",
     "lifecycle:active"
   ],
-  "packageManager": "yarn@3.8.1+sha512.8cfec856814c797ccb480703ca5270824327fac5abce240835e2699e01732229fd22bbeb1bb87047a0069f7698be9b2e3d9a926e6046e851faa9908fdacdeacf"
+  "packageManager": "yarn@1.22.22"
 }

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
@@ -54,6 +54,5 @@
   "keywords": [
     "support:tech-preview",
     "lifecycle:active"
-  ],
-  "packageManager": "yarn@1.22.22"
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

chore(yarn): switch to use Yarn v1 in showcase repo as v3 is not allowed yet

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.