### PR TITLE
[e2e] Fix: Enable default required plugins for scaffoldedfromlink test

### DIFF
--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -98,8 +98,8 @@ global:
           disabled: true
         - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
           disabled: false
-        # - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
-        #   disabled: false
+        - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+          disabled: false
         - package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
           disabled: false
         - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -12,6 +12,8 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `disabled` flag to disable/enable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
+        - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+          disabled: false
         - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
           disabled: false
           pluginConfig:
@@ -96,6 +98,8 @@ global:
           disabled: true
         - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
           disabled: false
+        # - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+        #   disabled: false
         - package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
           disabled: false
         - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic


### PR DESCRIPTION
## Description

1.3 nightly and PR checks Failing, Test catalog-scaffoldedfromLink.spec.ts is failing because the default plugins, which were previously enabled by default, are now disabled. : https://github.com/janus-idp/backstage-showcase/pull/1517

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-3729

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
