### PR TITLE
chore: tagRelease.sh: bump to 1.4.0 in main branch + regen yarn.lock

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showcase-app",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Showcase E2E test",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/packages/app/src/build-metadata.json
+++ b/packages/app/src/build-metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "RHDH Metadata",
   "card": [
-    "RHDH Version: 1.3.0",
+    "RHDH Version: 1.4.0",
     "Backstage Version: 1.29.2",
     "Last Commit: repo @ 2024-08-16T19:36:05Z"
   ]


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
