### PR TITLE
chore: add upstream repo reference since...

### DIFF
--- a/.github/workflows/pr-docker-build.yaml
+++ b/.github/workflows/pr-docker-build.yaml
@@ -49,9 +49,10 @@ jobs:
 
       - name: Get the latest commits from base branch
         run: |
+          git remote add base-origin https://github.com/janus-idp/backstage-showcase || true
           echo "Updating PR with latest commits from ${{ github.event.pull_request.base.ref }} ..."
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+          git fetch base-origin ${{ github.event.pull_request.base.ref }}
+          git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
       - name: Get the last commit short SHA of the PR
         run: |


### PR DESCRIPTION
### What does this PR do?

chore: add upstream repo reference since origin may map to a user's fork ([RHIDP-2313](https://issues.redhat.com//browse/RHIDP-2313))

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.