### PR TITLE
remove static installation of plugin-catalog-backend-module-logs

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,6 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "0.1.8",
     "@backstage/plugin-auth-node": "0.4.17",
     "@backstage/plugin-catalog-backend": "1.24.0",
-    "@backstage/plugin-catalog-backend-module-logs": "0.0.1",
     "@backstage/plugin-catalog-backend-module-openapi": "0.1.40",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "0.1.20",
     "@backstage/plugin-events-backend": "0.3.9",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -85,9 +85,6 @@ backend.add(import('@backstage/plugin-proxy-backend/alpha'));
 // TODO: Check in the Scaffolder new backend plugin why the identity is not passed and the default is built instead.
 backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
 
-// See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
-backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
-
 // search engine
 // See https://backstage.io/docs/features/search/search-engines
 backend.add(import('@backstage/plugin-search-backend-module-pg/alpha'));


### PR DESCRIPTION
## Description

Remove static installation of `@backstage/plugin-catalog-backend-module-logs`
* I've tested this change and confirmed that the error no longer occurs

When trying to test images locally and ran into this error. Since we now [provide this plugin dynamically](https://github.com/janus-idp/backstage-showcase/pull/1498), removing the static installation in the backend will fix this issue.

```
{"level":"info","message":"Listening on :7007","service":"rootHttpRouter","timestamp":"2024-09-03 16:05:13"}
/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1616
            throw new Error(
                  ^

Error: Module 'logs' for plugin 'catalog' is already registered
    at #doStart (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1616:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async BackendInitializer.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1562:5)
    at async BackstageBackend.start (/opt/app-root/src/node_modules/@backstage/backend-app-api/dist/index.cjs.js:1762:5)
```

## PR acceptance criteria
* The error does not appear when testing the image

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related