### PR TITLE
fix entityRef name when signing in without user in catalog

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -62,7 +62,7 @@ async function signInWithCatalogUserOptional(
         `Sign in failed: users/groups have not been ingested into the catalog. Please refer to the authentication provider docs for more information on how to ingest users/groups to the catalog with the appropriate entity provider.`,
       );
     }
-    let entityRef: string = name === 'string' ? name : '';
+    let entityRef: string = typeof name === 'string' ? name : '';
     if (typeof name !== 'string' && 'annotations' in name)
       entityRef = Object.values(name.annotations)[0];
     const userEntityRef = stringifyEntityRef({


### PR DESCRIPTION
## Description

When trying to login with GitHub auth, the following error appears when the user signing in is not present in the catalog.

`Login failed; caused by Error: "sub" claim provided by the auth resolver is not a valid EntityRef. `
 
## Which issue(s) does this PR fix

- Fixes [RHIDP-3896](https://issues.redhat.com/browse/RHIDP-3896)

## PR acceptance criteria
When `dangerouslyAllowSignInWithoutUserInCatalog` is set to true, there should not be any errors when logging in. 

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related