### PR TITLE
revert enabling dangerouslyAllowSignInWithoutUserInCatalog for GitHub

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -31,13 +31,11 @@ import { ConfigSources } from '@backstage/config-loader';
  *
  * @param name
  * @param ctx
- * @param enableDangerouslyAllowSignInWithoutUserInCatalog
  * @returns
  */
 async function signInWithCatalogUserOptional(
   name: string | AuthResolverCatalogUserQuery,
   ctx: AuthResolverContext,
-  enableDangerouslyAllowSignInWithoutUserInCatalog?: boolean,
 ) {
   try {
     const query: AuthResolverCatalogUserQuery =
@@ -55,7 +53,6 @@ async function signInWithCatalogUserOptional(
     );
     const dangerouslyAllowSignInWithoutUserInCatalog =
       config.getOptionalBoolean('dangerouslyAllowSignInWithoutUserInCatalog') ||
-      enableDangerouslyAllowSignInWithoutUserInCatalog ||
       false;
     if (!dangerouslyAllowSignInWithoutUserInCatalog) {
       throw new Error(
@@ -160,8 +157,7 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
                 `GitHub user profile does not contain a username`,
               );
             }
-            // enable dangerouslyAllowSignInWithoutUserInCatalog option temporarily for GitHub
-            return await signInWithCatalogUserOptional(userId, ctx, true);
+            return await signInWithCatalogUserOptional(userId, ctx);
           },
         },
       });


### PR DESCRIPTION
## Description

Reverting the temporary change by [this PR](https://github.com/janus-idp/backstage-showcase/pull/1468/files) as [the issue](https://issues.redhat.com/browse/RHIDP-3529) requiring this modification has been addressed.

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related