### PR TITLE
[e2e] Fix failure of `catalog-timestamp`

### DIFF
--- a/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
@@ -41,6 +41,7 @@ test.describe('Test timestamp column on Catalog', () => {
     await uiHelper.verifyRowInTableByUniqueText('timestamp-test', [
       /^\d{1,2}\/\d{1,2}\/\d{1,4}, \d:\d{1,2}:\d{1,2} (AM|PM)$/g,
     ]);
+    await uiHelper.searchInputPlaceholder('');
   });
 
   test('Toggle ‘CREATED AT’ to see if the component list can be sorted in ascending/decending order', async () => {

--- a/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
@@ -38,10 +38,9 @@ test.describe('Test timestamp column on Catalog', () => {
     await uiHelper.selectMuiBox('Kind', 'Component');
     await uiHelper.searchInputPlaceholder('timestamp-test');
     await uiHelper.verifyColumnHeading(['Created At'], true);
-    await uiHelper.verifyRowInTableByUniqueText('timestamp-test', [
+    await uiHelper.verifyRowInTableByUniqueText('timestamp-test-created', [
       /^\d{1,2}\/\d{1,2}\/\d{1,4}, \d:\d{1,2}:\d{1,2} (AM|PM)$/g,
     ]);
-    await uiHelper.searchInputPlaceholder('');
   });
 
   test('Toggle ‘CREATED AT’ to see if the component list can be sorted in ascending/decending order', async () => {


### PR DESCRIPTION
## Description

This is a follow-up to #1565, which fixed one test, but broke the following one. The second text expects the search field to be empty, but it is not cleared automatically.

## Which issue(s) does this PR fix

- Fixes [RHIDP-3967](https://issues.redhat.com/browse/RHIDP-3967)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
