### PR TITLE
fix(ui): allow empty string icon in menu item

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -75,7 +75,6 @@ const renderExpandIcon = (expand: boolean, isSecondLevelMenuItem = false) => {
 };
 
 const getMenuItem = (menuItem: ResolvedMenuItem, isNestedMenuItem = false) => {
-  if (!menuItem.icon) return null;
   const menuItemStyle = {
     paddingLeft: isNestedMenuItem ? '2rem' : '',
   };
@@ -83,7 +82,7 @@ const getMenuItem = (menuItem: ResolvedMenuItem, isNestedMenuItem = false) => {
     <Box key={menuItem.name} sx={{ '& a': menuItemStyle }}>
       <MyGroupsSidebarItem
         key={menuItem.name}
-        icon={renderIcon(menuItem.icon)}
+        icon={renderIcon(menuItem.icon ?? '')}
         singularTitle={menuItem.title}
         pluralTitle={`${menuItem.title}s`}
       />
@@ -91,7 +90,7 @@ const getMenuItem = (menuItem: ResolvedMenuItem, isNestedMenuItem = false) => {
   ) : (
     <SideBarItemWrapper
       key={menuItem.name}
-      icon={renderIcon(menuItem.icon)}
+      icon={renderIcon(menuItem.icon ?? '')}
       to={menuItem.to ?? ''}
       text={menuItem.title}
       style={menuItemStyle}


### PR DESCRIPTION
## Description

To allow sidebar menu items with empty string icon to be rendered.

## Which issue(s) does this PR fix

- Fixes [RHIDP-3989](https://issues.redhat.com/browse/RHIDP-3989)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Test with any dynamic plugin with `menuItem.icon` set to `''` in configuration. Such as
```
      dynamicRoutes:
        - path: /fcp-github-repo
          importName: FCPBackstageGitHubRepoTestHarness
          menuItem:
            text: FCP Github Repo
            icon: ''
```