### PR TITLE
fix(app): proxy for home and learning paths

### DIFF
--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -4,6 +4,7 @@ import {
   configApiRef,
   createApiFactory,
   discoveryApiRef,
+  identityApiRef,
   oauthRequestApiRef,
 } from '@backstage/core-plugin-api';
 import {
@@ -33,9 +34,10 @@ export const apis: AnyApiFactory[] = [
     deps: {
       discoveryApi: discoveryApiRef,
       configApi: configApiRef,
+      identityApi: identityApiRef,
     },
-    factory: ({ discoveryApi, configApi }) =>
-      new CustomDataApiClient({ discoveryApi, configApi }),
+    factory: ({ discoveryApi, configApi, identityApi }) =>
+      new CustomDataApiClient({ discoveryApi, configApi, identityApi }),
   }),
   // OIDC
   createApiFactory({


### PR DESCRIPTION
## Description

This PR updated the credentials to be passed for the proxy

See Backstage 1.28 release notes about the BREAKING: Proxy backend plugin protected by default -
https://github.com/backstage/backstage/releases/tag/v1.28.0 

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-4015 

## How to test changes / Special notes to the reviewer

1. Setup custom data for home page , follow https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/getting_started_with_red_hat_developer_hub/proc-customize-rhdh-homepage_rhdh-getting-started#proc-customize-rhdh-homepage_rhdh-getting-started 
2. Setup costom data for learning path, follow https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/getting_started_with_red_hat_developer_hub/proc-customize-rhdh-learning-paths_rhdh-getting-started 

- Using JSON files that are hosted or GitHub or GitLab. To access the data from the JSON files, add below to app-config.yaml

```
proxy:
  endpoints:
    '/developer-hub':
      target: https://raw.githubusercontent.com/
      pathRewrite:
        '^/api/proxy/developer-hub/learning-paths': '/janus-idp/backstage-showcase/main/packages/app/public/learning-paths/data.json'
        '^/api/proxy/developer-hub': '/janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json'
      changeOrigin: true
      secure: true
```

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
