### PR TITLE
fix(ui): allow empty icon for nested menu items

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -168,13 +168,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
                 unmountOnExit
               >
                 <List disablePadding>
-                  {child.icon &&
-                    child.children &&
-                    child.children.length === 0 && (
-                      <ListItem disableGutters disablePadding>
-                        {getMenuItem(child, true)}
-                      </ListItem>
-                    )}
+                  {child.children && child.children.length === 0 && (
+                    <ListItem disableGutters disablePadding>
+                      {getMenuItem(child, true)}
+                    </ListItem>
+                  )}
                   {child.children && child.children.length > 0 && (
                     <ListItem
                       disableGutters


### PR DESCRIPTION
## Description

Allow icons to be empty for sidebar nested menu items.

## Which issue(s) does this PR fix

- Fixes [RHIDP-3989](https://issues.redhat.com/browse/RHIDP-3989)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
Leave `icon` undefined and confirm nested menu items still get rendered in sidebar nested menu. For example the below config should render nested `User` and `Usage` under `Metrics`

```
    janus-idp.backstage-plugin-metrics:
      dynamicRoutes:
      - path: /metrics/users
        importName: MetricsUsersPage
      - path: /metrics/usage
        importName: MetricsUsagePage
      menuItems:
        metrics:
          title: Metrics
          icon: queryStats
          priority: -1
        metrics.users:
          parent: metrics
          title: Users
        metrics.usage:
          parent: metrics
          title: Usage
```

![image](https://github.com/user-attachments/assets/cb9847eb-a432-4c3f-82e3-9e9e935ce02d)
