### PR TITLE
clarify indentation level of config in auth documentation

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -186,4 +186,7 @@ To enable this option:
 
 ```yaml
 dangerouslyAllowSignInWithoutUserInCatalog: true
+auth:
+  providers:
+    # provider configs ...
 ```


### PR DESCRIPTION
## Description

When trying to set the `dangerouslyAllowSignInWithoutUserInCatalog` config, it is confusing which indentation to place the config at. This code snippet makes it more clear. 

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related