### PR TITLE
chore: tagRelease.sh: bump to 1.2.5 in 1.2.x branch + regen yarn.lock

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "showcase-app",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Showcase E2E test",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "private": true,
   "engines": {
     "node": "18 || 20"

--- a/packages/app/src/build-metadata.json
+++ b/packages/app/src/build-metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "RHDH Metadata",
   "card": [
-    "RHDH Version: 1.2.3",
+    "RHDH Version: 1.2.5",
     "Backstage Version: 1.26.5",
     "Last Commit: repo @ 2024-05-10T14:59:23Z"
   ]


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
