### PR TITLE
[Topology]: remove custom resources from k8s configuration

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -192,19 +192,6 @@ plugins:
     disabled: true
     pluginConfig:
       kubernetes:
-        customResources:
-          - group: 'tekton.dev'
-            apiVersion: 'v1beta1'
-            plural: 'pipelines'
-          - group: 'tekton.dev'
-            apiVersion: 'v1beta1'
-            plural: 'pipelineruns'
-          - group: 'tekton.dev'
-            apiVersion: 'v1beta1'
-            plural: 'taskruns'
-          - group: 'route.openshift.io'
-            apiVersion: 'v1'
-            plural: 'routes'
         serviceLocatorMethod:
           type: 'multiTenant'
         clusterLocatorMethods:


### PR DESCRIPTION
## Description

As a user configuring the Kubernetes settings, I specify a limited set of `objectTypes` that I want to view in the topology plugin. However, since RHDH includes pre-configured custom resources in its Kubernetes configuration, I might encounter warnings for resources like Tekton or Routes, which can be confusing as I haven't set up those resources. 


This PR removes custom resources that were pre-configured with the Kubernetes backend dynamic plugin configuration. This change eliminates warnings for resources that haven't been configured by the user.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-4240

Before
<img width="1484" alt="Screenshot 2024-09-30 at 6 08 35 PM" src="https://github.com/user-attachments/assets/5b2dc79d-83d8-403e-b417-68cd77116e2d">

After
<img width="1484" alt="Screenshot 2024-09-30 at 6 23 08 PM" src="https://github.com/user-attachments/assets/e6ec85be-0a35-4847-b4be-e02cc6405fa4">

<img width="1484" alt="Screenshot 2024-09-30 at 6 21 18 PM" src="https://github.com/user-attachments/assets/5e7a6a16-c5e3-4b1a-9242-85ce06114965">



## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

- Once the image of rhdh is generated for this PR, deploy it on a cluster. 
- Add the below Kubernetes configuration in the app-config without any custom resources. 
```
kubernetes:
      serviceLocatorMethod:
        type: 'multiTenant'
      objectTypes:
        - configmaps
        - deployments
        - limitranges
        - pods
        - services
        - statefulsets
        - replicasets
      clusterLocatorMethods:
          - type: 'config'
            clusters:
            - URL: <cluster-url>
              name: openshift
              authProvider: 'serviceAccount'
              skipTLSVerify: true
              skipMetricsLookup: true
              serviceAccountToken: <service-acc-token>
```

- You shouldn't see any tekton / routes related warnings
