### PR TITLE
[WIP] Switch AKS tests to `mapt` and spot instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ dynamic-plugins/*/dist-dynamic/src
 .webpack-cache
 .idea/
 .idea/
+
+# mapt temporary files
+.ibm/pipelines/.pulumi
+.ibm/pipelines/kubeconfig

--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -83,7 +83,7 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Install podman and required settings: https://github.com/containers/image_build/tree/main/podman & https://www.redhat.com/sysadmin/podman-inside-container
 RUN apt-get update -y && \
-    apt-get install -y podman fuse-overlayfs
+    apt-get install -y podman fuse-overlayfs containers-storage
     RUN useradd podman && \
     echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid && \
     echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid

--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -81,15 +81,38 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd6
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Install podman and required settings: https://www.redhat.com/sysadmin/podman-inside-container
+# Install podman and required settings: https://github.com/containers/image_build/tree/main/podman & https://www.redhat.com/sysadmin/podman-inside-container
 RUN apt-get update -y && \
     apt-get install -y podman fuse-overlayfs
-RUN useradd podman; \
-    echo podman:10000:5000 > /etc/subuid; \
-    echo podman:10000:5000 > /etc/subgid;
+    RUN useradd podman && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subuid && \
+    echo -e "podman:1:999\npodman:1001:64535" > /etc/subgid
+ADD https://raw.githubusercontent.com/containers/image_build/refs/heads/main/podman/containers.conf /etc/containers/containers.conf
+ADD https://raw.githubusercontent.com/containers/image_build/refs/heads/main/podman/podman-containers.conf /home/podman/.config/containers/containers.conf
+RUN mkdir -p /home/podman/.local/share/containers && \
+    chown podman:podman -R /home/podman && \
+    chmod 644 /etc/containers/containers.conf
+    RUN mkdir -p /home/podman/.local/share/containers && \
+    chown podman:podman -R /home/podman && \
+    chmod 644 /etc/containers/containers.conf
+RUN sed -e 's|^#mount_program|mount_program|g' \
+           -e '/additionalimage.*/a "/var/lib/shared",' \
+           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+           /usr/share/containers/storage.conf \
+           > /etc/containers/storage.conf
+RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 VOLUME /var/lib/containers
 VOLUME /home/podman/.local/share/containers
-RUN chown podman:podman -R /home/podman
+RUN mkdir -p /var/lib/shared/overlay-images \
+             /var/lib/shared/overlay-layers \
+             /var/lib/shared/vfs-images \
+             /var/lib/shared/vfs-layers && \
+    touch /var/lib/shared/overlay-images/images.lock && \
+    touch /var/lib/shared/overlay-layers/layers.lock && \
+    touch /var/lib/shared/vfs-images/images.lock && \
+    touch /var/lib/shared/vfs-layers/layers.lock
+ENV _CONTAINERS_USERNS_CONFIGURED="" \
+    BUILDAH_ISOLATION=chroot
 
 # Set environment variables to make Go work correctly
 ENV GOPATH /go

--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -81,9 +81,15 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd6
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Install podman
+# Install podman and required settings: https://www.redhat.com/sysadmin/podman-inside-container
 RUN apt-get update -y && \
-    apt-get install -y podman
+    apt-get install -y podman fuse-overlayfs
+RUN useradd podman; \
+    echo podman:10000:5000 > /etc/subuid; \
+    echo podman:10000:5000 > /etc/subgid;
+VOLUME /var/lib/containers
+VOLUME /home/podman/.local/share/containers
+RUN chown podman:podman -R /home/podman
 
 # Set environment variables to make Go work correctly
 ENV GOPATH /go

--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -81,6 +81,10 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.43.1/yq_linux_amd6
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
+# Install podman
+RUN apt-get update -y && \
+    apt-get install -y podman
+
 # Set environment variables to make Go work correctly
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -79,7 +79,5 @@ ARM_TENANT_ID=$(cat /tmp/secrets/ARM_TENANT_ID)
 ARM_SUBSCRIPTION_ID=$(cat /tmp/secrets/ARM_SUBSCRIPTION_ID)
 ARM_CLIENT_ID=$(cat /tmp/secrets/ARM_CLIENT_ID)
 ARM_CLIENT_SECRET=$(cat /tmp/secrets/ARM_CLIENT_SECRET)
-AKS_NIGHTLY_CLUSTER_NAME=$(cat /tmp/secrets/AKS_NIGHTLY_CLUSTER_NAME)
-AKS_NIGHTLY_CLUSTER_RESOURCEGROUP=$(cat /tmp/secrets/AKS_NIGHTLY_CLUSTER_RESOURCEGROUP)
 
 set +a  # Stop automatically exporting variables

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -376,7 +376,6 @@ main() {
   if [[ "$JOB_NAME" == *aks* ]]; then
     az_login
     mapt_aks_create
-    az_aks_approuting_enable "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
   fi
 
   install_oc

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -8,6 +8,7 @@ JUNIT_RESULTS="junit-results.xml"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 secret_name="rhdh-k8s-plugin-secret"
 OVERALL_RESULT=0
+JOB_NAME=periodic-aks
 
 cleanup() {
   echo "Cleaning up before exiting"

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -101,7 +101,7 @@ az_login() {
 }
 
 mapt_aks_create() {
-  podman run --security-opt label=disable -d --platform=linux/amd64 --rm --name create-aks \
+  podman run --security-opt label=disable --privileged -d --platform=linux/amd64 --rm --name create-aks \
       -v ${DIR}:/workspace:z \
       --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
@@ -122,7 +122,7 @@ mapt_aks_create() {
 }
 
 mapt_aks_destroy() {
-  podman run --security-opt label=disable -d --platform=linux/amd64 --rm --name destroy-aks \
+  podman run --security-opt label=disable --privileged -d --platform=linux/amd64 --rm --name destroy-aks \
       -v ${DIR}:/workspace:z \
       --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -101,9 +101,8 @@ az_login() {
 }
 
 mapt_aks_create() {
-  podman run --security-opt label=disable --privileged -d --platform=linux/amd64 --rm --name create-aks \
+  podman run --user podman --privileged -d --platform=linux/amd64 --rm --name create-aks \
       -v ${DIR}:/workspace:z \
-      --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
@@ -122,9 +121,8 @@ mapt_aks_create() {
 }
 
 mapt_aks_destroy() {
-  podman run --security-opt label=disable --privileged -d --platform=linux/amd64 --rm --name destroy-aks \
+  podman run --user podman --privileged -d --platform=linux/amd64 --rm --name destroy-aks \
       -v ${DIR}:/workspace:z \
-      --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -101,6 +101,8 @@ az_login() {
 }
 
 mapt_aks_create() {
+  cat /etc/subuid
+  cat /etc/subgid
   podman run --user podman --privileged -d --platform=linux/amd64 --rm --name create-aks \
       -v ${DIR}:/workspace:z \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -101,7 +101,7 @@ az_login() {
 }
 
 mapt_aks_create() {
-  podman run -d --privileged --platform=linux/amd64 --rm --name create-aks \
+  podman run --security-opt label=disable -d --platform=linux/amd64 --rm --name create-aks \
       -v ${DIR}:/workspace:z \
       --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
@@ -122,7 +122,7 @@ mapt_aks_create() {
 }
 
 mapt_aks_destroy() {
-  podman run -d --privileged --platform=linux/amd64 --rm --name destroy-aks \
+  podman run --security-opt label=disable -d --platform=linux/amd64 --rm --name destroy-aks \
       -v ${DIR}:/workspace:z \
       --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -101,7 +101,7 @@ az_login() {
 }
 
 mapt_aks_create() {
-  podman run -d --arch=amd64 --rm --name create-aks \
+  podman run -d --privileged --platform=linux/amd64 --rm --name create-aks \
       -v ${PWD}:/workspace:z \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
@@ -113,7 +113,7 @@ mapt_aks_create() {
           --backed-url "file:///workspace" \
           --conn-details-output "/workspace" \
           --spot
-  log_output=$(podman logs -f create-aks | tee /dev/tty)
+  local log_output=$(podman logs -f create-aks | tee /dev/tty)
   set +x
   export AKS_NIGHTLY_CLUSTER_RESOURCEGROUP=$(echo "$log_output" | grep -Eo 'mapt[0-9a-z]+' | head -n 1)
   export AKS_NIGHTLY_CLUSTER_NAME=$(echo "$log_output" | grep -Eo 'aks-aaks-cluster[0-9a-z]+' | head -n 1)
@@ -121,7 +121,7 @@ mapt_aks_create() {
 }
 
 mapt_aks_destroy() {
-  podman run -d --rm --name destroy-aks \
+  podman run -d --privileged --platform=linux/amd64 --rm --name destroy-aks \
       -v ${PWD}:/workspace:z \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -107,17 +107,14 @@ mapt_aks_create() {
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
       -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
-      quay.io/rhqp/mapt:v0.7.0-dev azure \
+      quay.io/rhqp/mapt:v0.7.0 azure \
           aks create \
           --project-name "aks" \
           --backed-url "file:///workspace" \
           --conn-details-output "/workspace" \
-          --spot
-  local log_output=$(podman logs -f create-aks | tee /dev/tty)
-  set +x
-  export AKS_NIGHTLY_CLUSTER_RESOURCEGROUP=$(echo "$log_output" | grep -Eo 'mapt[0-9a-z]+' | head -n 1)
-  export AKS_NIGHTLY_CLUSTER_NAME=$(echo "$log_output" | grep -Eo 'aks-aaks-cluster[0-9a-z]+' | head -n 1)
-  set -x
+          --spot \
+          --enable-app-routing
+  podman logs -f create-aks
 }
 
 mapt_aks_destroy() {
@@ -127,7 +124,7 @@ mapt_aks_destroy() {
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
       -e ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET} \
-      quay.io/rhqp/mapt:v0.7.0-dev azure \
+      quay.io/rhqp/mapt:v0.7.0 azure \
           aks destroy \
           --project-name "aks" \
           --backed-url "file:///workspace" 

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -103,6 +103,7 @@ az_login() {
 mapt_aks_create() {
   podman run -d --privileged --platform=linux/amd64 --rm --name create-aks \
       -v ${DIR}:/workspace:z \
+      --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
@@ -123,6 +124,7 @@ mapt_aks_create() {
 mapt_aks_destroy() {
   podman run -d --privileged --platform=linux/amd64 --rm --name destroy-aks \
       -v ${DIR}:/workspace:z \
+      --userns=keep-id \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -102,7 +102,7 @@ az_login() {
 
 mapt_aks_create() {
   podman run -d --privileged --platform=linux/amd64 --rm --name create-aks \
-      -v ${PWD}:/workspace:z \
+      -v ${DIR}:/workspace:z \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \
@@ -122,7 +122,7 @@ mapt_aks_create() {
 
 mapt_aks_destroy() {
   podman run -d --privileged --platform=linux/amd64 --rm --name destroy-aks \
-      -v ${PWD}:/workspace:z \
+      -v ${DIR}:/workspace:z \
       -e ARM_TENANT_ID=${ARM_TENANT_ID} \
       -e ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID} \
       -e ARM_CLIENT_ID=${ARM_CLIENT_ID} \


### PR DESCRIPTION
## Description

This PR is switching the AKS nightly tests from long running cluster (that goes to sleep and wake up) to a spot instance (that is created and then destroyed). This approach allows us to save costs on Azure and gives us a fresh cluster every time, to avoid hiccups that the long running clusters might encounter.

This PR depends on having the https://github.com/janus-idp/backstage-showcase/pull/1643 merged first, to be able to use different auth provider than GitHub for majority of tests. GitHub requires a static callback URL (which is not achievable with `mapt`, but might be in the future: https://github.com/redhat-developer/mapt/issues/273). GitHub is also not the most stable auth provider and tests sometimes fail because of it.

The same approach as for AKS will be possible for GKE after `mapt` adds support: https://github.com/redhat-developer/mapt/issues/290

## Which issue(s) does this PR fix

- Fixes [RHIDP-4268](https://issues.redhat.com/browse/RHIDP-3500)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
