### PR TITLE
fix: fix GitLab auth by resolving via username not userId

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -166,9 +166,11 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
       return providers.gitlab.create({
         signIn: {
           async resolver({ result: { fullProfile } }, ctx) {
-            const userId = fullProfile.id;
+            const userId = fullProfile.username;
             if (!userId) {
-              throw new Error(`GitLab user profile does not contain an id`);
+              throw new Error(
+                `GitLab user profile does not contain an username`,
+              );
             }
             return await signInWithCatalogUserOptional(userId, ctx);
           },


### PR DESCRIPTION
## Description

When authenticating with GitLab, users were not able to be resolved because the authenticator was trying to resolve via `userId` which is not a valid parameter when users are added via [Catalog Backend Module for GitLab Organizational Data](https://github.com/backstage/backstage/tree/master/plugins/catalog-backend-module-gitlab-org).

This PR fixes this by resolving via the username instead.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4349](https://issues.redhat.com/browse/RHIDP-4349) & [RHDHBUGS-87](https://issues.redhat.com/browse/RHDHBUGS-87)

## PR acceptance criteria
Users are able to sign in with GitLab. 

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related
