### PR TITLE
[e2e] Fix `droute` limiting attachment size

### DIFF
--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -90,7 +90,6 @@ droute_send() {
     --username '${DATA_ROUTER_USERNAME}' \
     --password '${DATA_ROUTER_PASSWORD}' \
     --results '/tmp/droute/${JUNIT_RESULTS}' \
-    --attachments '/tmp/droute/attachments' \
     --verbose"
 
 }


### PR DESCRIPTION
## Description

`droute` started applying limit to the attachment size that was not communicated or mentioned in their documentation.
## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
