### PR TITLE
chore: Move techdocs plugin from dependency to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     ]
   },
   "dependencies": {
-    "@backstage/plugin-techdocs-backend": "1.10.13",
     "node-gyp": "9.4.1",
     "patch-package": "8.0.0",
     "postinstall-postinstall": "2.1.0"
@@ -60,7 +59,8 @@
   },
   "resolutions": {
     "@types/react": "18.3.7",
-    "@types/react-dom": "18.3.0"
+    "@types/react-dom": "18.3.0",
+    "@backstage/plugin-techdocs-backend": "1.10.13"
   },
   "jest": {
     "testTimeout": 20000

--- a/yarn.lock
+++ b/yarn.lock
@@ -7379,7 +7379,7 @@
     uuid "^9.0.0"
     winston "^3.2.1"
 
-"@backstage/plugin-search-backend-module-techdocs@0.1.27", "@backstage/plugin-search-backend-module-techdocs@^0.1.27":
+"@backstage/plugin-search-backend-module-techdocs@0.1.27":
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-module-techdocs/-/plugin-search-backend-module-techdocs-0.1.27.tgz#da3403f5ad591d2a66702678fb4fa6a4a20db67f"
   integrity sha512-JnqLycCYS27W5o64QrpIdsuBAsvs/PsR4u9mhG3PzYvXtXXkitYzLDspQHHFTQc2LUyCoMkyPdLGl0cX3QAAjA==
@@ -7546,7 +7546,7 @@
     "@backstage/types" "^1.1.1"
     "@material-ui/core" "^4.12.4"
 
-"@backstage/plugin-techdocs-backend@1.10.13":
+"@backstage/plugin-techdocs-backend@1.10.13", "@backstage/plugin-techdocs-backend@1.10.9":
   version "1.10.13"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-techdocs-backend/-/plugin-techdocs-backend-1.10.13.tgz#80f7b2aee543e4c3d99ee012e6c9e42c7e6359c7"
   integrity sha512-dtbdEHKFaxCbM2m/O9jWXH20MRpWSFFTp6RhWNXmFIfMEh0bgVJazXBSJEo8RVt8te1ob1O9ArcxNxIww4IY4w==
@@ -7571,32 +7571,6 @@
     knex "^3.0.0"
     lodash "^4.17.21"
     node-fetch "^2.7.0"
-    p-limit "^3.1.0"
-    winston "^3.2.1"
-
-"@backstage/plugin-techdocs-backend@1.10.9":
-  version "1.10.9"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-techdocs-backend/-/plugin-techdocs-backend-1.10.9.tgz#731c1fd5ea84d2cd64f85b1ff61f53f594e8cedd"
-  integrity sha512-/0elT2n2onBfHv1YKQx84uDsg+nPbH86RL9IiT8riM3hlxLHeNUlzDLeLy1uQ3f003tYcZB5qSybk5u+KGtXlQ==
-  dependencies:
-    "@backstage/backend-common" "^0.23.3"
-    "@backstage/backend-plugin-api" "^0.7.0"
-    "@backstage/catalog-client" "^1.6.5"
-    "@backstage/catalog-model" "^1.5.0"
-    "@backstage/config" "^1.2.0"
-    "@backstage/errors" "^1.2.4"
-    "@backstage/integration" "^1.13.0"
-    "@backstage/plugin-catalog-common" "^1.0.25"
-    "@backstage/plugin-permission-common" "^0.8.0"
-    "@backstage/plugin-search-backend-module-techdocs" "^0.1.27"
-    "@backstage/plugin-techdocs-node" "^1.12.8"
-    "@types/express" "^4.17.6"
-    express "^4.17.1"
-    express-promise-router "^4.1.0"
-    fs-extra "^11.2.0"
-    knex "^3.0.0"
-    lodash "^4.17.21"
-    node-fetch "^2.6.7"
     p-limit "^3.1.0"
     winston "^3.2.1"
 


### PR DESCRIPTION
The techdocs update was inadvertently placed in the dependencies section of the package.json instead of the resolutions section, which is corrected by this pull request.

