### PR TITLE
chore(npm registry default): set default npm registry to https://registry.npmjs.org/ instead of cachito; also set path to cafile (RHIDP-4410)

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -177,10 +177,9 @@ COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
 
 # Install production dependencies
 # hadolint ignore=DL3059
-RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
-
-# delete all the nested .npmrc files and set default values
-RUN find . -type f -name .npmrc -exec rm -Rf {} \; && \
+RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000 && \
+    # delete all the nested .npmrc files and set default values
+    find . -type f -name .npmrc -exec rm -Rf {} \; && \
     # reset npm config to the default registry and absolute path to .pem file
     npm config set registry=https://registry.npmjs.org/ && \
     npm config set cafile /opt/app-root/src/registry-ca.pem

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -234,6 +234,9 @@ RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
 RUN mkdir /opt/app-root/src/.npm
 RUN chown -R 1001:1001 /opt/app-root/src/.npm
 
+# default npm config to the default registry, not the cachito one
+RUN npm config set registry=https://registry.npmjs.org/; npm config get registry; npm config set cafile /opt/app-root/src/registry-ca.pem
+
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -179,6 +179,10 @@ COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
+# default npm config to the default registry, not the cachito one
+RUN npm config set registry=https://registry.npmjs.org/; \
+    npm config set cafile /opt/app-root/src/registry-ca.pem
+
 # Stage 5 - Build the runner image
 #@follow_tag(registry.access.redhat.com/ubi9/nodejs-20-minimal:1)
 # https://registry.access.redhat.com/ubi9/nodejs-20-minimal
@@ -233,9 +237,6 @@ RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
 # Downstream only - fix for https://issues.redhat.com/browse/RHIDP-728
 RUN mkdir /opt/app-root/src/.npm
 RUN chown -R 1001:1001 /opt/app-root/src/.npm
-
-# default npm config to the default registry, not the cachito one
-RUN npm config set registry=https://registry.npmjs.org/; npm config get registry; npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -179,8 +179,9 @@ COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
-# default npm config to the default registry, not the cachito one
-RUN npm config set registry=https://registry.npmjs.org/; \
+# default npm config to the default registry, not the cachito one - delete all the nested .npmrc files and set default values
+RUN find . -type f -name .npmrc -exec rm -Rf {} \;
+    npm config set registry=https://registry.npmjs.org/; \
     npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # Stage 5 - Build the runner image

--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -179,9 +179,10 @@ COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
-# default npm config to the default registry, not the cachito one - delete all the nested .npmrc files and set default values
-RUN find . -type f -name .npmrc -exec rm -Rf {} \;
-    npm config set registry=https://registry.npmjs.org/; \
+# delete all the nested .npmrc files and set default values
+RUN find . -type f -name .npmrc -exec rm -Rf {} \; && \
+    # reset npm config to the default registry and absolute path to .pem file
+    npm config set registry=https://registry.npmjs.org/ && \
     npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # Stage 5 - Build the runner image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,10 +106,9 @@ COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 
 # Install production dependencies
 # hadolint ignore=DL3059
-RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
-
-# delete all the nested .npmrc files and set default values
-RUN find . -type f -name .npmrc -exec rm -Rf {} \; && \
+RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000 && \
+    # delete all the nested .npmrc files and set default values
+    find . -type f -name .npmrc -exec rm -Rf {} \; && \
     # reset npm config to the default registry and absolute path to .pem file
     npm config set registry=https://registry.npmjs.org/ && \
     npm config set cafile /opt/app-root/src/registry-ca.pem

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,9 +108,10 @@ COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
-# default npm config to the default registry, not the cachito one - delete all the nested .npmrc files and set default values
-RUN find . -type f -name .npmrc -exec rm -Rf {} \;
-    npm config set registry=https://registry.npmjs.org/; \
+# delete all the nested .npmrc files and set default values
+RUN find . -type f -name .npmrc -exec rm -Rf {} \; && \
+    # reset npm config to the default registry and absolute path to .pem file
+    npm config set registry=https://registry.npmjs.org/ && \
     npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # Stage 5 - Build the runner image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,6 +108,10 @@ COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
+# default npm config to the default registry, not the cachito one
+RUN npm config set registry=https://registry.npmjs.org/; \
+    npm config set cafile /opt/app-root/src/registry-ca.pem
+
 # Stage 5 - Build the runner image
 # https://registry.access.redhat.com/ubi9/nodejs-20-minimal
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:1-63.1725851021 AS runner
@@ -139,9 +143,6 @@ COPY $EXTERNAL_SOURCE_NESTED/patches/ ./patches/
 COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
   chmod -R a+rx ./install-dynamic-plugins.sh;
-
-# default npm config to the default registry, not the cachito one
-RUN npm config set registry=https://registry.npmjs.org/; npm config get registry; npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,8 +108,9 @@ COPY $EXTERNAL_SOURCE_NESTED/dynamic-plugins.default.yaml ./
 # hadolint ignore=DL3059
 RUN "$YARN" install --frozen-lockfile --production --network-timeout 600000
 
-# default npm config to the default registry, not the cachito one
-RUN npm config set registry=https://registry.npmjs.org/; \
+# default npm config to the default registry, not the cachito one - delete all the nested .npmrc files and set default values
+RUN find . -type f -name .npmrc -exec rm -Rf {} \;
+    npm config set registry=https://registry.npmjs.org/; \
     npm config set cafile /opt/app-root/src/registry-ca.pem
 
 # Stage 5 - Build the runner image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,6 +140,9 @@ COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
   chmod -R a+rx ./install-dynamic-plugins.sh;
 
+# default npm config to the default registry, not the cachito one
+RUN npm config set registry=https://registry.npmjs.org/; npm config get registry; npm config set cafile /opt/app-root/src/registry-ca.pem
+
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./


### PR DESCRIPTION
### What does this PR do?

chore(npm registry default): set default npm registry to https://registry.npmjs.org/ instead of cachito; also set path to cafile  ([RHIDP-4410](https://issues.redhat.com//browse/RHIDP-4410))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.