### PR TITLE
chore(e2e): fix aks tests

### DIFF
--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
         '**/playwright/e2e/plugins/rbac/**/*.spec.ts',
         '**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts',
         '**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts',
+        '**/playwright/e2e/authProviders/**/*.spec.ts',
         '**/playwright/e2e/plugins/bulk-import.spec.ts',
         '**/playwright/e2e/plugins/tekton/tekton.spec.ts',
         '**/playwright/e2e/catalog-scaffoldedfromLink.spec.ts',


### PR DESCRIPTION
## Description

AKS nightly jobs are currently failing due to recently added authProvider tests https://github.com/janus-idp/backstage-showcase/pull/1643 . These tests need to be skipped for AKS clusters, following the same pattern we hav for showcase OCP clusters. 

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-4444 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
