### PR TITLE
chore(release): [1.2] verifying plugins have been released to npmjs.com and bumping versions

### DIFF
--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -20,7 +20,7 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.6.15",
     "@janus-idp/backstage-plugin-acr": "1.4.13",
     "@janus-idp/backstage-plugin-analytics-provider-segment": "1.4.9",
-    "@janus-idp/backstage-plugin-jfrog-artifactory": "1.4.10",
+    "@janus-idp/backstage-plugin-jfrog-artifactory": "1.7.4",
     "@janus-idp/backstage-plugin-keycloak-backend": "1.9.12",
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.6.10",
     "@janus-idp/backstage-plugin-ocm": "4.1.8",

--- a/dynamic-plugins/imports/package.json
+++ b/dynamic-plugins/imports/package.json
@@ -20,7 +20,7 @@
     "@janus-idp/backstage-plugin-aap-backend": "1.6.15",
     "@janus-idp/backstage-plugin-acr": "1.4.13",
     "@janus-idp/backstage-plugin-analytics-provider-segment": "1.4.9",
-    "@janus-idp/backstage-plugin-jfrog-artifactory": "1.4.11",
+    "@janus-idp/backstage-plugin-jfrog-artifactory": "1.4.10",
     "@janus-idp/backstage-plugin-keycloak-backend": "1.9.12",
     "@janus-idp/backstage-plugin-nexus-repository-manager": "1.6.10",
     "@janus-idp/backstage-plugin-ocm": "4.1.8",


### PR DESCRIPTION
## Description

This PR is to bump the plugin-jfrog-artifactory to a newer version for the 1.2.5 release. The main and release-1.3 branches have a newer version of this plugin, but this 1.2.x branch needs a version of the plugin that is not 4 months old.

[@janus-idp/backstage-plugin-jfrog-artifactory](https://www.npmjs.com/package/@janus-idp/backstage-plugin-jfrog-artifactory) 

## Which issue(s) does this PR fix

- Fixes #? https://issues.redhat.com/browse/RHIDP-4217

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
