### PR TITLE
fix: avoid double rendering of menuItems backed by custom components

### DIFF
--- a/packages/app/src/utils/dynamicUI/extractDynamicConfigFrontend.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfigFrontend.ts
@@ -78,7 +78,7 @@ export function extractMenuItems(frontend: FrontendConfig): MenuItem[] {
       customProperties.dynamicRoutes.forEach(dr => {
         const itemName = getNameFromPath(dr.path);
         const mi = dr.menuItem;
-        if (mi && isStaticPath(dr.path)) {
+        if (mi && isStaticPath(dr.path) && !dr.importName) {
           items.push({
             name: itemName,
             icon: 'icon' in mi && mi.icon ? mi.icon : '',


### PR DESCRIPTION
## Description

When dynamicRoutes[].menuItem.importName is used to render the left-side menuItem of a FE dynamic plugin, the item is rendered twice. Once without the text (title), second time via the importName-component as expected.

This fix leaves the menuItem up to rendering via dynamicRoutesComponents and removes it from the menuItems array.

Example config causing the issue:
```
dynamicPlugins:
  frontend:
    redhat.plugin-notifications:
      dynamicRoutes:
        - importName: NotificationsPage
          path: /notifications
          menuItem:
            # HERE:
            importName: NotificationsSidebarItem
            config:
              props: ...
```

The issue is fixed by filtering in the `main` branch within new `buildTree()` function in `extractDynamicConfigFrontend.ts`. The 1.3 branch does not have this new nested navigation, so fixing it separately.

## Which issue(s) does this PR fix

- Fixes [FLPATH-1777](https://issues.redhat.com//browse/FLPATH-1777)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
