### PR TITLE
chore(deps): remove dset version 3.1.4 from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   "resolutions": {
     "@types/react": "18.2.48",
     "@types/react-dom": "18.2.18",
-    "body-parser": "^1.20.3",
-    "dset": "^3.1.4"
+    "body-parser": "^1.20.3"
   },
   "jest": {
     "testTimeout": 20000

--- a/yarn.lock
+++ b/yarn.lock
@@ -17024,7 +17024,7 @@ drange@^1.0.2:
   resolved "https://registry.yarnpkg.com/drange/-/drange-1.1.1.tgz#b2aecec2aab82fcef11dbbd7b9e32b83f8f6c0b8"
   integrity sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==
 
-dset@^3.1.2, dset@^3.1.4:
+dset@^3.1.2:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.4.tgz#f8eaf5f023f068a036d08cd07dc9ffb7d0065248"
   integrity sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==


### PR DESCRIPTION
## Description

This PR, removes `"dset": "^3.1.4"` from resolutions within the 1.2.x branch, undoing this PR: https://github.com/janus-idp/backstage-showcase/pull/1718/files

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
