### PR TITLE
fix(app): proxy for tech-radar

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-tech-radar/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-tech-radar/src/index.ts
@@ -3,6 +3,7 @@ import {
   configApiRef,
   createApiFactory,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { CustomTechRadar } from './api/CustomTechRadar';
 
@@ -13,9 +14,10 @@ export const TechRadarApi = createApiFactory({
   deps: {
     discoveryApi: discoveryApiRef,
     configApi: configApiRef,
+    identityApi: identityApiRef,
   },
-  factory: ({ discoveryApi, configApi }) =>
-    new CustomTechRadar({ discoveryApi, configApi }),
+  factory: ({ discoveryApi, configApi, identityApi }) =>
+    new CustomTechRadar({ discoveryApi, configApi, identityApi }),
 });
 
 export { default as TechRadarIcon } from '@mui/icons-material/MyLocation';


### PR DESCRIPTION
## Description

Fixes: https://issues.redhat.com/browse/RHDHBUGS-99

This PR updated the credentials to be passed for the proxy

See Backstage 1.28 release notes about the BREAKING: Proxy backend plugin protected by default -
https://github.com/backstage/backstage/releases/tag/v1.28.0 

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHDHBUGS-99

## How to test changes / Special notes to the reviewer

1. Setup custom data for techradar page , follow https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html/getting_started_with_red_hat_developer_hub/proc-customize-rhdh-tech-radar-page_rhdh-getting-started#using-hosted-json-files-to-provide-data-to-the-tech-radar-page


- Using JSON files that are hosted or GitHub or GitLab. To access the data from the JSON files, add below to app-config.yaml

```
proxy:
  endpoints:
    '/developer-hub':
      target: https://raw.githubusercontent.com/
      pathRewrite:
        '^/api/proxy/developer-hub/learning-paths': '/janus-idp/backstage-showcase/main/packages/app/public/learning-paths/data.json'
        '^/api/proxy/developer-hub/tech-radar':  '/janus-idp/backstage-showcase/main/dynamic-plugins/wrappers/backstage-plugin-tech-radar/src/data/data-default.json'
        '^/api/proxy/developer-hub': '/janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json'
      changeOrigin: true
      secure: true
```

**Screenshot:**

<img width="961" alt="image" src="https://github.com/user-attachments/assets/7daad8a2-7982-40f0-bd58-8bb7cb791611">


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
