### PR TITLE
chore(e2e): automate custom theme dynamic plugin

### DIFF
--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -10,17 +10,6 @@ data:
       branding:
         fullLogo: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDIwMDEwOTA0Ly9FTiIgImh0dHA6Ly93d3cudzMub3JnL1RSLzIwMDEvUkVDLVNWRy0yMDAxMDkwNC9EVEQvc3ZnMTAuZHRkIj4KPCEtLSBDcmVhdGVkIHVzaW5nIEtyaXRhOiBodHRwczovL2tyaXRhLm9yZyAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIAogICAgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiCiAgICB4bWxuczprcml0YT0iaHR0cDovL2tyaXRhLm9yZy9uYW1lc3BhY2VzL3N2Zy9rcml0YSIKICAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgIHdpZHRoPSIxNjBwdCIKICAgIGhlaWdodD0iODBwdCIKICAgIHZpZXdCb3g9IjAgMCAxNjAgODAiPgo8ZGVmcy8+Cjx0ZXh0IGlkPSJzaGFwZTAiIGtyaXRhOnVzZVJpY2hUZXh0PSJ0cnVlIiB0ZXh0LXJlbmRlcmluZz0iYXV0byIga3JpdGE6dGV4dFZlcnNpb249IjMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0wLjE3NzMyMDYxNTAzNDE1NSwgNTQuMjYyNSkiIGZpbGw9IiNmZmZmZmYiIHN0cm9rZS1vcGFjaXR5PSIwIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMCIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJiZXZlbCIgbGV0dGVyLXNwYWNpbmc9IjAiIHdvcmQtc3BhY2luZz0iMCIgc3R5bGU9InRleHQtYWxpZ246IHN0YXJ0O3RleHQtYWxpZ24tbGFzdDogYXV0bztmb250LWZhbWlseTogUmVkIEhhdCBEaXNwbGF5O2ZvbnQtc2l6ZTogNDA7Zm9udC13ZWlnaHQ6IDcwMDsiPjx0c3BhbiB4PSIwIj5RRTwvdHNwYW4+PC90ZXh0Pjx0ZXh0IGlkPSJzaGFwZTEiIGtyaXRhOnVzZVJpY2hUZXh0PSJ0cnVlIiB0ZXh0LXJlbmRlcmluZz0iYXV0byIga3JpdGE6dGV4dFZlcnNpb249IjMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDU3LjU2NDgyMDYxNTAzNDIsIDM1LjcyOTY4NzUpIiBmaWxsPSIjZmZmZmZmIiBzdHJva2Utb3BhY2l0eT0iMCIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjAiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiIHN0cm9rZS1saW5lam9pbj0iYmV2ZWwiIGxldHRlci1zcGFjaW5nPSIwIiB3b3JkLXNwYWNpbmc9IjAiIHN0eWxlPSJ0ZXh0LWFsaWduOiBzdGFydDt0ZXh0LWFsaWduLWxhc3Q6IGF1dG87Zm9udC1mYW1pbHk6IFJlZCBIYXQgVGV4dDtmb250LXNpemU6IDE0O2ZvbnQtd2VpZ2h0OiA3MDA7Ij48dHNwYW4geD0iMCI+UmVkIEhhdDwvdHNwYW4+PHRzcGFuIHg9IjAiIGR5PSIxOC41MTU2MjUiPkRldmVsb3BlciBIdWI8L3RzcGFuPjwvdGV4dD4KPC9zdmc+Cg=="
         iconLogo: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDIwMDEwOTA0Ly9FTiIgImh0dHA6Ly93d3cudzMub3JnL1RSLzIwMDEvUkVDLVNWRy0yMDAxMDkwNC9EVEQvc3ZnMTAuZHRkIj4KPCEtLSBDcmVhdGVkIHVzaW5nIEtyaXRhOiBodHRwczovL2tyaXRhLm9yZyAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIAogICAgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiCiAgICB4bWxuczprcml0YT0iaHR0cDovL2tyaXRhLm9yZy9uYW1lc3BhY2VzL3N2Zy9rcml0YSIKICAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgIHdpZHRoPSI4MHB0IgogICAgaGVpZ2h0PSI4MHB0IgogICAgdmlld0JveD0iMCAwIDgwIDgwIj4KPGRlZnMvPgo8dGV4dCBpZD0ic2hhcGUwIiBrcml0YTp1c2VSaWNoVGV4dD0idHJ1ZSIgdGV4dC1yZW5kZXJpbmc9ImF1dG8iIGtyaXRhOnRleHRWZXJzaW9uPSIzIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjU5OTk5OTk5OTk5OTk5LCA2Mi44MTI1KSIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlLW9wYWNpdHk9IjAiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSIwIiBzdHJva2UtbGluZWNhcD0ic3F1YXJlIiBzdHJva2UtbGluZWpvaW49ImJldmVsIiBsZXR0ZXItc3BhY2luZz0iMCIgd29yZC1zcGFjaW5nPSIwIiBzdHlsZT0idGV4dC1hbGlnbjogc3RhcnQ7dGV4dC1hbGlnbi1sYXN0OiBhdXRvO2ZvbnQtZmFtaWx5OiBSZWQgSGF0IE1vbm87Zm9udC1zaXplOiA2NDtmb250LXdlaWdodDogNzAwOyI+PHRzcGFuIHg9IjAiPlFFPC90c3Bhbj48L3RleHQ+Cjwvc3ZnPgo="
-        theme:
-          light:
-            primaryColor: "rgb(255, 95, 21)"
-            headerColor1: "rgb(248, 248, 248)"
-            headerColor2: "rgb(248, 248, 248)"
-            navigationIndicatorColor: "rgb(255,95,21)"
-          dark:
-            primaryColor: '#ab75cf'
-            headerColor1: 'rgb(0, 0, 208)'
-            headerColor2: 'rgb(255, 246, 140)'
-            navigationIndicatorColor: 'rgb(244, 238, 169)'
     dynamicPlugins:
       rootDirectory: dynamic-plugins-root
       frontend:
@@ -42,6 +31,23 @@ data:
             docs:
               parent: favorites
               priority: 1
+        pataknight.backstage-plugin-rhdh-qe-theme:
+          appIcons:
+          - importName: LightIcon
+            name: lightIcon
+          - importName: DarkIcon
+            name: darkIcon
+          themes:
+          - icon: lightIcon
+            id: light
+            importName: lightThemeProvider
+            title: Light
+            variant: light
+          - icon: darkIcon
+            id: dark
+            importName: darkThemeProvider
+            title: Dark
+            variant: dark
     backend:
       auth:
         keys:

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -10,6 +10,17 @@ data:
       branding:
         fullLogo: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDIwMDEwOTA0Ly9FTiIgImh0dHA6Ly93d3cudzMub3JnL1RSLzIwMDEvUkVDLVNWRy0yMDAxMDkwNC9EVEQvc3ZnMTAuZHRkIj4KPCEtLSBDcmVhdGVkIHVzaW5nIEtyaXRhOiBodHRwczovL2tyaXRhLm9yZyAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIAogICAgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiCiAgICB4bWxuczprcml0YT0iaHR0cDovL2tyaXRhLm9yZy9uYW1lc3BhY2VzL3N2Zy9rcml0YSIKICAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgIHdpZHRoPSIxNjBwdCIKICAgIGhlaWdodD0iODBwdCIKICAgIHZpZXdCb3g9IjAgMCAxNjAgODAiPgo8ZGVmcy8+Cjx0ZXh0IGlkPSJzaGFwZTAiIGtyaXRhOnVzZVJpY2hUZXh0PSJ0cnVlIiB0ZXh0LXJlbmRlcmluZz0iYXV0byIga3JpdGE6dGV4dFZlcnNpb249IjMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0wLjE3NzMyMDYxNTAzNDE1NSwgNTQuMjYyNSkiIGZpbGw9IiNmZmZmZmYiIHN0cm9rZS1vcGFjaXR5PSIwIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMCIgc3Ryb2tlLWxpbmVjYXA9InNxdWFyZSIgc3Ryb2tlLWxpbmVqb2luPSJiZXZlbCIgbGV0dGVyLXNwYWNpbmc9IjAiIHdvcmQtc3BhY2luZz0iMCIgc3R5bGU9InRleHQtYWxpZ246IHN0YXJ0O3RleHQtYWxpZ24tbGFzdDogYXV0bztmb250LWZhbWlseTogUmVkIEhhdCBEaXNwbGF5O2ZvbnQtc2l6ZTogNDA7Zm9udC13ZWlnaHQ6IDcwMDsiPjx0c3BhbiB4PSIwIj5RRTwvdHNwYW4+PC90ZXh0Pjx0ZXh0IGlkPSJzaGFwZTEiIGtyaXRhOnVzZVJpY2hUZXh0PSJ0cnVlIiB0ZXh0LXJlbmRlcmluZz0iYXV0byIga3JpdGE6dGV4dFZlcnNpb249IjMiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDU3LjU2NDgyMDYxNTAzNDIsIDM1LjcyOTY4NzUpIiBmaWxsPSIjZmZmZmZmIiBzdHJva2Utb3BhY2l0eT0iMCIgc3Ryb2tlPSIjMDAwMDAwIiBzdHJva2Utd2lkdGg9IjAiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiIHN0cm9rZS1saW5lam9pbj0iYmV2ZWwiIGxldHRlci1zcGFjaW5nPSIwIiB3b3JkLXNwYWNpbmc9IjAiIHN0eWxlPSJ0ZXh0LWFsaWduOiBzdGFydDt0ZXh0LWFsaWduLWxhc3Q6IGF1dG87Zm9udC1mYW1pbHk6IFJlZCBIYXQgVGV4dDtmb250LXNpemU6IDE0O2ZvbnQtd2VpZ2h0OiA3MDA7Ij48dHNwYW4geD0iMCI+UmVkIEhhdDwvdHNwYW4+PHRzcGFuIHg9IjAiIGR5PSIxOC41MTU2MjUiPkRldmVsb3BlciBIdWI8L3RzcGFuPjwvdGV4dD4KPC9zdmc+Cg=="
         iconLogo: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pgo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDIwMDEwOTA0Ly9FTiIgImh0dHA6Ly93d3cudzMub3JnL1RSLzIwMDEvUkVDLVNWRy0yMDAxMDkwNC9EVEQvc3ZnMTAuZHRkIj4KPCEtLSBDcmVhdGVkIHVzaW5nIEtyaXRhOiBodHRwczovL2tyaXRhLm9yZyAtLT4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIAogICAgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiCiAgICB4bWxuczprcml0YT0iaHR0cDovL2tyaXRhLm9yZy9uYW1lc3BhY2VzL3N2Zy9rcml0YSIKICAgIHhtbG5zOnNvZGlwb2RpPSJodHRwOi8vc29kaXBvZGkuc291cmNlZm9yZ2UubmV0L0RURC9zb2RpcG9kaS0wLmR0ZCIKICAgIHdpZHRoPSI4MHB0IgogICAgaGVpZ2h0PSI4MHB0IgogICAgdmlld0JveD0iMCAwIDgwIDgwIj4KPGRlZnMvPgo8dGV4dCBpZD0ic2hhcGUwIiBrcml0YTp1c2VSaWNoVGV4dD0idHJ1ZSIgdGV4dC1yZW5kZXJpbmc9ImF1dG8iIGtyaXRhOnRleHRWZXJzaW9uPSIzIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxLjU5OTk5OTk5OTk5OTk5LCA2Mi44MTI1KSIgZmlsbD0iI2ZmZmZmZiIgc3Ryb2tlLW9wYWNpdHk9IjAiIHN0cm9rZT0iIzAwMDAwMCIgc3Ryb2tlLXdpZHRoPSIwIiBzdHJva2UtbGluZWNhcD0ic3F1YXJlIiBzdHJva2UtbGluZWpvaW49ImJldmVsIiBsZXR0ZXItc3BhY2luZz0iMCIgd29yZC1zcGFjaW5nPSIwIiBzdHlsZT0idGV4dC1hbGlnbjogc3RhcnQ7dGV4dC1hbGlnbi1sYXN0OiBhdXRvO2ZvbnQtZmFtaWx5OiBSZWQgSGF0IE1vbm87Zm9udC1zaXplOiA2NDtmb250LXdlaWdodDogNzAwOyI+PHRzcGFuIHg9IjAiPlFFPC90c3Bhbj48L3RleHQ+Cjwvc3ZnPgo="
+        theme:
+          light:
+            primaryColor: "#2A61A7"
+            headerColor1: "rgb(216, 98, 208)"
+            headerColor2: "rgb(216, 164, 98)"
+            navigationIndicatorColor: "rgb(98, 216, 105)"
+          dark:
+            primaryColor: '#DC6ED9'
+            headerColor1: 'rgb(190, 122, 45)'
+            headerColor2: 'rgb(45, 190, 50)'
+            navigationIndicatorColor: 'rgb(45, 113, 190)'
     dynamicPlugins:
       rootDirectory: dynamic-plugins-root
       frontend:
@@ -39,14 +50,14 @@ data:
             name: darkIcon
           themes:
           - icon: lightIcon
-            id: light
+            id: light-dynamic
             importName: lightThemeProvider
-            title: Light
+            title: Light Dynamic
             variant: light
           - icon: darkIcon
-            id: dark
+            id: dark-dynamic
             importName: darkThemeProvider
-            title: Dark
+            title: Dark Dynamic
             variant: dark
     backend:
       auth:

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -111,6 +111,9 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
         disabled: false
+      - package: '@pataknight/backstage-plugin-rhdh-qe-theme@0.5.5'
+        disabled: false
+        integrity: sha512-srTnFDYn3Ett6z33bX4nL2NQY8wqux8TkpgBQNsE8S73nMfsor/wAdmVgHL+xW7pxQ09DT4YTdaG3GkH+cyyNQ==
 
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 upstream:

--- a/dynamic-plugins/_utils/src/wrappers.test.ts
+++ b/dynamic-plugins/_utils/src/wrappers.test.ts
@@ -64,12 +64,14 @@ type DynamicPluginAppConfig = {
   dynamicPlugins?: { frontend?: Record<string, unknown> };
 };
 
+type DynamicPluginConfig = {
+  package: string;
+  disabled?: boolean;
+  pluginConfig?: DynamicPluginAppConfig;
+};
+
 type DynamicPluginsConfig = {
-  plugins: {
-    package: string;
-    disabled?: boolean;
-    pluginConfig?: DynamicPluginAppConfig;
-  }[];
+  plugins: DynamicPluginConfig[];
 };
 
 type GlobalDynamicPluginsConfig = {
@@ -110,11 +112,14 @@ function parseYamlFile<T>(filePath: string): T {
 function validateDynamicPluginsConfig(
   config: DynamicPluginsConfig,
   wrapperDirNames: string[],
+  externalDynamicPlugin?: DynamicPluginConfig,
 ): void {
   const dynamicPluginsPackageNames = config.plugins.reduce(
     (packageNames, plugin) => {
-      // We want the third index ['.', 'dynamic-plugins', 'dist', 'backstage-plugin-scaffolder-backend-module-github-dynamic']
-      packageNames.push(plugin.package.split("/")[3]);
+      if (externalDynamicPlugin?.package !== plugin.package) {
+        // We want the third index ['.', 'dynamic-plugins', 'dist', 'backstage-plugin-scaffolder-backend-module-github-dynamic']
+        packageNames.push(plugin.package.split("/")[3]);
+      }
 
       return packageNames;
     },
@@ -235,8 +240,17 @@ describe("Dynamic Plugin Wrappers", () => {
       IBM_VALUES_SHOWCASE_CONFIG_FILE,
     );
 
+    const externalDynamicPluginConfig: DynamicPluginConfig = {
+      package: "@pataknight/backstage-plugin-rhdh-qe-theme@0.5.5",
+      disabled: false,
+    };
+
     it("should have a corresponding package", () => {
-      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames);
+      validateDynamicPluginsConfig(
+        config.global.dynamic,
+        wrapperDirNames,
+        externalDynamicPluginConfig,
+      );
     });
   });
 

--- a/dynamic-plugins/_utils/src/wrappers.test.ts
+++ b/dynamic-plugins/_utils/src/wrappers.test.ts
@@ -1,173 +1,272 @@
 import { glob } from "glob";
-import fs from 'node:fs';
-import path from 'node:path';
-import yaml from 'yaml';
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "yaml";
 
 const PACKAGE_JSON_GLOB = "**/package.json";
 const IGNORE_GLOB = ["**/node_modules/**", "**/dist-dynamic/**"];
 
 const ROOT_DIR = path.join(__dirname, "../../..");
 const DYNAMIC_PLUGINS_DIR = path.join(ROOT_DIR, "dynamic-plugins/wrappers");
-const DYNAMIC_PLUGINS_CONFIG_FILE = path.join(ROOT_DIR, 'dynamic-plugins.default.yaml')
-const APP_CONFIG_DYNAMIC_PLUGINS_CONFIG_FILE = path.join(ROOT_DIR, 'app-config.dynamic-plugins.yaml')
-const IBM_VALUES_SHOWCASE_CONFIG_FILE = path.join(ROOT_DIR, '.ibm/pipelines/value_files/values_showcase.yaml')
-const IBM_VALUES_SHOWCASE_RBAC_CONFIG_FILE = path.join(ROOT_DIR, '.ibm/pipelines/value_files/values_showcase-rbac.yaml')
-const IBM_VALUES_SHOWCASE_AUTH_PROVIDERS_CONFIG_FILE = path.join(ROOT_DIR, '.ibm/pipelines/value_files/values_showcase-auth-providers.yaml')
-const RHDH_OPENSHIFT_SETUP_CONFIG_FILE = path.join(ROOT_DIR, 'scripts/rhdh-openshift-setup/values.yaml')
+const DYNAMIC_PLUGINS_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  "dynamic-plugins.default.yaml",
+);
+const APP_CONFIG_DYNAMIC_PLUGINS_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  "app-config.dynamic-plugins.yaml",
+);
+const IBM_VALUES_SHOWCASE_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  ".ibm/pipelines/value_files/values_showcase.yaml",
+);
+const IBM_VALUES_SHOWCASE_RBAC_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  ".ibm/pipelines/value_files/values_showcase-rbac.yaml",
+);
+const IBM_VALUES_SHOWCASE_AUTH_PROVIDERS_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  ".ibm/pipelines/value_files/values_showcase-auth-providers.yaml",
+);
+const RHDH_OPENSHIFT_SETUP_CONFIG_FILE = path.join(
+  ROOT_DIR,
+  "scripts/rhdh-openshift-setup/values.yaml",
+);
 
 type WrapperFrontendPackageJson = {
   name: string;
   backstage: {
-    role: 'frontend-plugin';
+    role: "frontend-plugin";
   };
   scalprum: {
     name: string;
   };
   repository: {
     directory: string;
-  }
-}
+  };
+};
 
 type WrapperBackendPackageJson = {
   name: string;
   backstage: {
-    role: 'backend-plugin' | 'backend-plugin-module';
+    role: "backend-plugin" | "backend-plugin-module";
   };
   repository: {
     directory: string;
-  }
-}
+  };
+};
 
-type WrapperPackageJson = WrapperFrontendPackageJson | WrapperBackendPackageJson
+type WrapperPackageJson =
+  | WrapperFrontendPackageJson
+  | WrapperBackendPackageJson;
 
-type DynamicPluginAppConfig = { dynamicPlugins?: { frontend?: Record<string, unknown> } }
+type DynamicPluginAppConfig = {
+  dynamicPlugins?: { frontend?: Record<string, unknown> };
+};
 
 type DynamicPluginsConfig = {
-  plugins: { package: string, disabled?: boolean, pluginConfig?: DynamicPluginAppConfig }[]
-}
+  plugins: {
+    package: string;
+    disabled?: boolean;
+    pluginConfig?: DynamicPluginAppConfig;
+  }[];
+};
 
 type GlobalDynamicPluginsConfig = {
-  global: { dynamic: { plugins: { package: string, disabled?: boolean, pluginConfig?: DynamicPluginAppConfig }[] } }
+  global: {
+    dynamic: {
+      plugins: {
+        package: string;
+        disabled?: boolean;
+        pluginConfig?: DynamicPluginAppConfig;
+      }[];
+    };
+  };
+};
+
+function isFrontendPlugin(
+  packageJson: WrapperPackageJson,
+): packageJson is WrapperFrontendPackageJson {
+  return packageJson.backstage.role === "frontend-plugin";
 }
 
-function isFrontendPlugin(packageJson: WrapperPackageJson): packageJson is WrapperFrontendPackageJson {
-  return packageJson.backstage.role === 'frontend-plugin'
-}
-
-function isBackendPlugin(packageJson: WrapperPackageJson): packageJson is WrapperBackendPackageJson {
-  return packageJson.backstage.role === 'backend-plugin' || packageJson.backstage.role === 'backend-plugin-module'
+function isBackendPlugin(
+  packageJson: WrapperPackageJson,
+): packageJson is WrapperBackendPackageJson {
+  return (
+    packageJson.backstage.role === "backend-plugin" ||
+    packageJson.backstage.role === "backend-plugin-module"
+  );
 }
 
 function getDifference<T>(arrA: T[], arrB: T[]): T[] {
-  return arrA.filter(x => !arrB.includes(x));
+  return arrA.filter((x) => !arrB.includes(x));
 }
 
 function parseYamlFile<T>(filePath: string): T {
   return yaml.parse(fs.readFileSync(filePath).toString());
 }
 
-function validateDynamicPluginsConfig(config: DynamicPluginsConfig, wrapperDirNames: string[]): void {
-  const dynamicPluginsPackageNames = config.plugins.reduce((packageNames, plugin) => {
-    // We want the third index ['.', 'dynamic-plugins', 'dist', 'backstage-plugin-scaffolder-backend-module-github-dynamic']
-    packageNames.push(plugin.package.split('/')[3])
+function validateDynamicPluginsConfig(
+  config: DynamicPluginsConfig,
+  wrapperDirNames: string[],
+): void {
+  const dynamicPluginsPackageNames = config.plugins.reduce(
+    (packageNames, plugin) => {
+      // We want the third index ['.', 'dynamic-plugins', 'dist', 'backstage-plugin-scaffolder-backend-module-github-dynamic']
+      packageNames.push(plugin.package.split("/")[3]);
 
-    return packageNames
-  }, [] as string[])
+      return packageNames;
+    },
+    [] as string[],
+  );
 
-
-  const difference = getDifference(dynamicPluginsPackageNames, wrapperDirNames)
+  const difference = getDifference(dynamicPluginsPackageNames, wrapperDirNames);
 
   try {
-    expect(difference).toStrictEqual([])
+    expect(difference).toStrictEqual([]);
   } catch {
-    throw new Error(`The following plugins are missing: ${difference.join(', ')}`)
+    throw new Error(
+      `The following plugins are missing: ${difference.join(", ")}`,
+    );
   }
 }
 
-describe('Dynamic Plugin Wrappers', () => {
+describe("Dynamic Plugin Wrappers", () => {
   const wrapperPackageJsonPaths = glob.sync(PACKAGE_JSON_GLOB, {
     cwd: DYNAMIC_PLUGINS_DIR, // Search only within DYNAMIC_PLUGINS_DIR
     ignore: IGNORE_GLOB,
   });
 
-  const wrapperDirNames = wrapperPackageJsonPaths.map(path.dirname)
+  const wrapperDirNames = wrapperPackageJsonPaths.map(path.dirname);
 
-  const wrapperPackageJsonFiles = wrapperPackageJsonPaths.map((packageJsonPath) => {
-    const packageJson = fs.readFileSync(path.join(DYNAMIC_PLUGINS_DIR, packageJsonPath))
-    return JSON.parse(packageJson.toString()) as WrapperPackageJson
-  })
-  const frontendPackageJsonFiles = wrapperPackageJsonFiles.filter((packageJson) => isFrontendPlugin(packageJson))
-  const backendPackageJsonFiles = wrapperPackageJsonFiles.filter((packageJson) => isBackendPlugin(packageJson))
+  const wrapperPackageJsonFiles = wrapperPackageJsonPaths.map(
+    (packageJsonPath) => {
+      const packageJson = fs.readFileSync(
+        path.join(DYNAMIC_PLUGINS_DIR, packageJsonPath),
+      );
+      return JSON.parse(packageJson.toString()) as WrapperPackageJson;
+    },
+  );
+  const frontendPackageJsonFiles = wrapperPackageJsonFiles.filter(
+    (packageJson) => isFrontendPlugin(packageJson),
+  );
+  const backendPackageJsonFiles = wrapperPackageJsonFiles.filter(
+    (packageJson) => isBackendPlugin(packageJson),
+  );
 
   describe("Backend Plugin", () => {
-    it.each(backendPackageJsonFiles)('$name should have a `-dynamic` suffix in the directory name', ({ name, repository }) => {
-      const hasDynamicSuffix = wrapperPackageJsonPaths.some(value => value.includes(`${name}-dynamic`));
-      expect(hasDynamicSuffix).toBeTruthy();
-      expect(repository.directory).toBe(`dynamic-plugins/wrappers/${name}-dynamic`)
-    })
-  })
+    it.each(backendPackageJsonFiles)(
+      "$name should have a `-dynamic` suffix in the directory name",
+      ({ name, repository }) => {
+        const hasDynamicSuffix = wrapperPackageJsonPaths.some((value) =>
+          value.includes(`${name}-dynamic`),
+        );
+        expect(hasDynamicSuffix).toBeTruthy();
+        expect(repository.directory).toBe(
+          `dynamic-plugins/wrappers/${name}-dynamic`,
+        );
+      },
+    );
+  });
 
   describe("Frontend Plugin", () => {
-    it.each(frontendPackageJsonFiles)('$name should have a matching directory name', ({ name, repository }) => {
-      const hasMatchingDirName = wrapperPackageJsonPaths.some((value) => value.includes(name))
-      expect(hasMatchingDirName).toBeTruthy()
-      expect(repository.directory).toBe(`dynamic-plugins/wrappers/${name}`)
-    })
+    it.each(frontendPackageJsonFiles)(
+      "$name should have a matching directory name",
+      ({ name, repository }) => {
+        const hasMatchingDirName = wrapperPackageJsonPaths.some((value) =>
+          value.includes(name),
+        );
+        expect(hasMatchingDirName).toBeTruthy();
+        expect(repository.directory).toBe(`dynamic-plugins/wrappers/${name}`);
+      },
+    );
 
-    it.each(frontendPackageJsonFiles)('$name should have scalprum config in the `package.json`', ({ name, scalprum }) => {
-      expect(scalprum).toBeTruthy()
-    })
-  })
+    it.each(frontendPackageJsonFiles)(
+      "$name should have scalprum config in the `package.json`",
+      ({ name, scalprum }) => {
+        expect(scalprum).toBeTruthy();
+      },
+    );
+  });
 
-  describe('(dynamic-plugins.default.yaml) should have a valid config', () => {
-    const config = parseYamlFile<DynamicPluginsConfig>(DYNAMIC_PLUGINS_CONFIG_FILE)
+  describe("(dynamic-plugins.default.yaml) should have a valid config", () => {
+    const config = parseYamlFile<DynamicPluginsConfig>(
+      DYNAMIC_PLUGINS_CONFIG_FILE,
+    );
 
-    it('should have a corresponding package', () => {
-      validateDynamicPluginsConfig(config, wrapperDirNames)
-    })
+    it("should have a corresponding package", () => {
+      validateDynamicPluginsConfig(config, wrapperDirNames);
+    });
 
-    it.each(frontendPackageJsonFiles)('$scalprum.name should exist in the config', ({ scalprum }) => {
-      expect(config.plugins.some((plugin) => Object.keys(plugin.pluginConfig?.dynamicPlugins?.frontend ?? {}).includes(scalprum.name))).toBeTruthy()
-    })
-  })
+    it.each(frontendPackageJsonFiles)(
+      "$scalprum.name should exist in the config",
+      ({ scalprum }) => {
+        expect(
+          config.plugins.some((plugin) =>
+            Object.keys(
+              plugin.pluginConfig?.dynamicPlugins?.frontend ?? {},
+            ).includes(scalprum.name),
+          ),
+        ).toBeTruthy();
+      },
+    );
+  });
 
-  describe('(app-config.dynamic-plugins.yaml) should have a valid config', () => {
-    const config = parseYamlFile<DynamicPluginAppConfig>(APP_CONFIG_DYNAMIC_PLUGINS_CONFIG_FILE)
+  describe("(app-config.dynamic-plugins.yaml) should have a valid config", () => {
+    const config = parseYamlFile<DynamicPluginAppConfig>(
+      APP_CONFIG_DYNAMIC_PLUGINS_CONFIG_FILE,
+    );
 
-    it.each(frontendPackageJsonFiles)('$scalprum.name should exist in the config', ({ scalprum }) => {
-      expect(Object.keys(config?.dynamicPlugins?.frontend ?? {}).includes(scalprum.name)).toBeTruthy()
-    })
-  })
+    it.each(frontendPackageJsonFiles)(
+      "$scalprum.name should exist in the config",
+      ({ scalprum }) => {
+        expect(
+          Object.keys(config?.dynamicPlugins?.frontend ?? {}).includes(
+            scalprum.name,
+          ),
+        ).toBeTruthy();
+      },
+    );
+  });
 
-  describe('(ibm: values_showcase.yaml) should have a valid config', () => {
-    const config = parseYamlFile<GlobalDynamicPluginsConfig>(IBM_VALUES_SHOWCASE_CONFIG_FILE)
+  describe("(ibm: values_showcase.yaml) should have a valid config", () => {
+    const config = parseYamlFile<GlobalDynamicPluginsConfig>(
+      IBM_VALUES_SHOWCASE_CONFIG_FILE,
+    );
 
-    it('should have a corresponding package', () => {
-      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames)
-    })
-  })
+    it("should have a corresponding package", () => {
+      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames);
+    });
+  });
 
-  describe('(ibm: values_showcase-rbac.yaml) should have a valid config', () => {
-    const config = parseYamlFile<GlobalDynamicPluginsConfig>(IBM_VALUES_SHOWCASE_RBAC_CONFIG_FILE)
+  describe("(ibm: values_showcase-rbac.yaml) should have a valid config", () => {
+    const config = parseYamlFile<GlobalDynamicPluginsConfig>(
+      IBM_VALUES_SHOWCASE_RBAC_CONFIG_FILE,
+    );
 
-    it('should have a corresponding package', () => {
-      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames)
-    })
-  })
+    it("should have a corresponding package", () => {
+      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames);
+    });
+  });
 
-  describe('(ibm: values_showcase_auth-providers.yaml) should have a valid config', () => {
-    const config = parseYamlFile<GlobalDynamicPluginsConfig>(IBM_VALUES_SHOWCASE_AUTH_PROVIDERS_CONFIG_FILE)
+  describe("(ibm: values_showcase_auth-providers.yaml) should have a valid config", () => {
+    const config = parseYamlFile<GlobalDynamicPluginsConfig>(
+      IBM_VALUES_SHOWCASE_AUTH_PROVIDERS_CONFIG_FILE,
+    );
 
-    it('should have a corresponding package', () => {
-      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames)
-    })
-  })
+    it("should have a corresponding package", () => {
+      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames);
+    });
+  });
 
-  describe('(rhdh-openshift-setup: values.yaml) should have a valid config', () => {
-    const config = parseYamlFile<GlobalDynamicPluginsConfig>(RHDH_OPENSHIFT_SETUP_CONFIG_FILE)
+  describe("(rhdh-openshift-setup: values.yaml) should have a valid config", () => {
+    const config = parseYamlFile<GlobalDynamicPluginsConfig>(
+      RHDH_OPENSHIFT_SETUP_CONFIG_FILE,
+    );
 
-    it('should have a corresponding package', () => {
-      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames)
-    })
-  })
-})
+    it("should have a corresponding package", () => {
+      validateDynamicPluginsConfig(config.global.dynamic, wrapperDirNames);
+    });
+  });
+});

--- a/e2e-tests/playwright/data/theme-constants.ts
+++ b/e2e-tests/playwright/data/theme-constants.ts
@@ -1,0 +1,45 @@
+type ThemeInfo = {
+  name: "Light" | "Dark" | "Light Dynamic" | "Dark Dynamic";
+  primaryColor: string;
+  headerColor1: string;
+  headerColor2: string;
+  navigationIndicatorColor: string;
+};
+
+export class ThemeConstants {
+  static getThemes() {
+    const light: ThemeInfo = {
+      name: "Light",
+      primaryColor: "#2A61A7",
+      headerColor1: "rgb(216, 98, 208)",
+      headerColor2: "rgb(216, 164, 98)",
+      navigationIndicatorColor: "rgb(98, 216, 105)",
+    };
+
+    const dark: ThemeInfo = {
+      name: "Dark",
+      primaryColor: "#DC6ED9",
+      headerColor1: "rgb(190, 122, 45)",
+      headerColor2: "rgb(45, 190, 50)",
+      navigationIndicatorColor: "rgb(45, 113, 190)",
+    };
+
+    const lightDynamic: ThemeInfo = {
+      name: "Light Dynamic",
+      primaryColor: "rgb(255, 95, 21)",
+      headerColor1: "rgb(248, 248, 248)",
+      headerColor2: "rgb(248, 248, 248)",
+      navigationIndicatorColor: "rgb(255, 95, 21)",
+    };
+
+    const darkDynamic: ThemeInfo = {
+      name: "Dark Dynamic",
+      primaryColor: "#ab75cf",
+      headerColor1: "rgb(0, 0, 208)",
+      headerColor2: "rgb(255, 246, 140)",
+      navigationIndicatorColor: "rgb(244, 238, 169)",
+    };
+
+    return [light, dark, lightDynamic, darkDynamic];
+  }
+}

--- a/e2e-tests/playwright/e2e/custom-theme.spec.ts
+++ b/e2e-tests/playwright/e2e/custom-theme.spec.ts
@@ -21,8 +21,38 @@ test.describe("CustomTheme should be applied", () => {
   });
 
   // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme light colors are applied and make screenshots", async ({}, testInfo: TestInfo) => {
+  test("Verify that theme light colors are applied using static red hat developer theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
     await themeVerifier.setTheme("Light");
+    await themeVerifier.verifyHeaderGradient(
+      "none, linear-gradient(90deg, rgb(216, 98, 208), rgb(216, 164, 98))",
+    );
+    await themeVerifier.verifyBorderLeftColor("rgb(98, 216, 105)");
+    await themeVerifier.takeScreenshotAndAttach(
+      "screenshots/custom-theme-light-inspection.png",
+      testInfo,
+      "custom-theme-light-inspection",
+    );
+    await themeVerifier.verifyPrimaryColors("#2A61A7");
+  });
+
+  // eslint-disable-next-line no-empty-pattern
+  test("Verify that theme dark colors are applied using static red hat developer theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
+    await themeVerifier.setTheme("Dark");
+    await themeVerifier.verifyHeaderGradient(
+      "none, linear-gradient(90deg, rgb(190, 122, 45), rgb(45, 190, 50))",
+    );
+    await themeVerifier.verifyBorderLeftColor("rgb(45, 113, 190)");
+    await themeVerifier.takeScreenshotAndAttach(
+      "screenshots/custom-theme-dark-inspection.png",
+      testInfo,
+      "custom-theme-dark-inspection",
+    );
+    await themeVerifier.verifyPrimaryColors("#DC6ED9");
+  });
+
+  // eslint-disable-next-line no-empty-pattern
+  test("Verify that theme light colors are applied using custom dynamic theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
+    await themeVerifier.setTheme("Light Dynamic");
     await themeVerifier.verifyHeaderGradient(
       "none, linear-gradient(90deg, rgb(248, 248, 248), rgb(248, 248, 248))",
     );
@@ -36,8 +66,8 @@ test.describe("CustomTheme should be applied", () => {
   });
 
   // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme dark colors are applied and make screenshots", async ({}, testInfo: TestInfo) => {
-    await themeVerifier.setTheme("Dark");
+  test("Verify that theme dark colors are applied using custom dynamic theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
+    await themeVerifier.setTheme("Dark Dynamic");
     await themeVerifier.verifyHeaderGradient(
       "none, linear-gradient(90deg, rgb(0, 0, 208), rgb(255, 246, 140))",
     );

--- a/e2e-tests/playwright/e2e/custom-theme.spec.ts
+++ b/e2e-tests/playwright/e2e/custom-theme.spec.ts
@@ -5,6 +5,7 @@ import {
   customTabIcon,
   customBrandIcon,
 } from "../support/testData/custom-theme";
+import { ThemeConstants } from "../data/theme-constants";
 
 let page: Page;
 
@@ -20,64 +21,22 @@ test.describe("CustomTheme should be applied", () => {
     await common.loginAsGuest();
   });
 
-  // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme light colors are applied using static red hat developer theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
-    await themeVerifier.setTheme("Light");
-    await themeVerifier.verifyHeaderGradient(
-      "none, linear-gradient(90deg, rgb(216, 98, 208), rgb(216, 164, 98))",
-    );
-    await themeVerifier.verifyBorderLeftColor("rgb(98, 216, 105)");
-    await themeVerifier.takeScreenshotAndAttach(
-      "screenshots/custom-theme-light-inspection.png",
-      testInfo,
-      "custom-theme-light-inspection",
-    );
-    await themeVerifier.verifyPrimaryColors("#2A61A7");
-  });
+  test("Verify theme colors are applied and make screenshots", async (_args, testInfo: TestInfo) => {
+    const themes = ThemeConstants.getThemes();
 
-  // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme dark colors are applied using static red hat developer theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
-    await themeVerifier.setTheme("Dark");
-    await themeVerifier.verifyHeaderGradient(
-      "none, linear-gradient(90deg, rgb(190, 122, 45), rgb(45, 190, 50))",
-    );
-    await themeVerifier.verifyBorderLeftColor("rgb(45, 113, 190)");
-    await themeVerifier.takeScreenshotAndAttach(
-      "screenshots/custom-theme-dark-inspection.png",
-      testInfo,
-      "custom-theme-dark-inspection",
-    );
-    await themeVerifier.verifyPrimaryColors("#DC6ED9");
-  });
-
-  // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme light colors are applied using custom dynamic theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
-    await themeVerifier.setTheme("Light Dynamic");
-    await themeVerifier.verifyHeaderGradient(
-      "none, linear-gradient(90deg, rgb(248, 248, 248), rgb(248, 248, 248))",
-    );
-    await themeVerifier.verifyBorderLeftColor("rgb(255, 95, 21)");
-    await themeVerifier.takeScreenshotAndAttach(
-      "screenshots/custom-theme-light-inspection.png",
-      testInfo,
-      "custom-theme-light-inspection",
-    );
-    await themeVerifier.verifyPrimaryColors("rgb(255, 95, 21)");
-  });
-
-  // eslint-disable-next-line no-empty-pattern
-  test("Verify that theme dark colors are applied using custom dynamic theme plugin and make screenshots", async ({}, testInfo: TestInfo) => {
-    await themeVerifier.setTheme("Dark Dynamic");
-    await themeVerifier.verifyHeaderGradient(
-      "none, linear-gradient(90deg, rgb(0, 0, 208), rgb(255, 246, 140))",
-    );
-    await themeVerifier.verifyBorderLeftColor("rgb(244, 238, 169)");
-    await themeVerifier.takeScreenshotAndAttach(
-      "screenshots/custom-theme-dark-inspection.png",
-      testInfo,
-      "custom-theme-dark-inspection",
-    );
-    await themeVerifier.verifyPrimaryColors("#ab75cf");
+    for (const theme of themes) {
+      await themeVerifier.setTheme(theme.name);
+      await themeVerifier.verifyHeaderGradient(
+        `none, linear-gradient(90deg, ${theme.headerColor1}, ${theme.headerColor2})`,
+      );
+      await themeVerifier.verifyBorderLeftColor(theme.navigationIndicatorColor);
+      await themeVerifier.takeScreenshotAndAttach(
+        `screenshots/custom-theme-${theme.name}-inspection.png`,
+        testInfo,
+        `custom-theme-${theme.name}-inspection`,
+      );
+      await themeVerifier.verifyPrimaryColors(theme.primaryColor);
+    }
   });
 
   test("Verify that tab icon for Backstage can be customized", async () => {

--- a/e2e-tests/playwright/e2e/custom-theme.spec.ts
+++ b/e2e-tests/playwright/e2e/custom-theme.spec.ts
@@ -21,7 +21,8 @@ test.describe("CustomTheme should be applied", () => {
     await common.loginAsGuest();
   });
 
-  test("Verify theme colors are applied and make screenshots", async (_args, testInfo: TestInfo) => {
+  // eslint-disable-next-line no-empty-pattern
+  test("Verify theme colors are applied and make screenshots", async ({}, testInfo: TestInfo) => {
     const themes = ThemeConstants.getThemes();
 
     for (const theme of themes) {

--- a/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
+++ b/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
@@ -11,7 +11,7 @@ export class ThemeVerifier {
     this.uiHelper = new UIhelper(page);
   }
 
-  async setTheme(theme: "Light" | "Dark") {
+  async setTheme(theme: "Light" | "Dark" | "Light Dynamic" | "Dark Dynamic") {
     await this.uiHelper.openSidebar("Settings");
     await this.uiHelper.clickBtnByTitleIfNotPressed(`Select theme ${theme}`);
   }


### PR DESCRIPTION
## Description

Updates the app-config to now load a custom theme plugin to satisfy the ability to load custom themes dynamically.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4462](https://issues.redhat.com/browse/RHIDP-4462)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

There are a couple of things that are worth discussing within this PR.

First, I am using a custom theme plugin that I created and is currently under my name. Ideally, a better alternative would be to move this to a place that the qe team owns / has more control over. I was wondering where that location would be most appropriate and how we want to manage ownership moving forward.
- [Plugin repo](https://github.com/PatAKnight/qe-theme-dynamic-plugins)
- [NPM plugin](https://www.npmjs.com/package/@pataknight/backstage-plugin-rhdh-qe-theme)

Second, this test technically overrides the static feature of overriding the theme that is being handled by the `@redhat-developer/red-hat-developer-hub-theme`. The underlying tests didn't need to change because I created the custom theme plugin using the values that we were overriding. I chose a blanket override of all things theme related. We can definitely mix and match if we still want to be able to test both plugins. But figured that it would be best left up for discussion.