### PR TITLE
chore(e2e): introduce kubernetes actions namespace test

### DIFF
--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -125,6 +125,8 @@ data:
         - type: url
           target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
         - type: url
+          target: https://github.com/janus-idp/backstage-plugins/blob/main/plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
+        - type: url
           target: https://github.com/janus-qe/acr-catalog/blob/main/catalog-info.yaml
         - type: url
           target: https://github.com/janus-qe/rhdh-test/blob/main/user.yml

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -74,7 +74,7 @@ test.describe.serial('GitHub Happy path', () => {
     await uiHelper.waitForHeaderTitle();
 
     for (const template of templates) {
-      await uiHelper.waitForH4Title(template);
+      await uiHelper.waitForTitle(template, 4);
       await uiHelper.verifyHeading(template);
     }
   });

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -1,0 +1,53 @@
+import { Page, test } from '@playwright/test';
+import { Common, setupBrowser } from '../../../../playwright/utils/Common';
+import { UIhelper } from '../../../../playwright/utils/UIhelper';
+import { exec } from 'child_process';
+
+test.describe('Test Kubernetes Actions plugin', () => {
+  let common: Common;
+  let uiHelper: UIhelper;
+  let page: Page;
+
+  test.beforeAll(async ({ browser }, testInfo) => {
+    page = (await setupBrowser(browser, testInfo)).page;
+    common = new Common(page);
+    await common.loginAsGuest();
+    uiHelper = new UIhelper(page);
+    await uiHelper.openSidebar('Create...');
+  });
+
+  test('Creates kubernetes namespace', async () => {
+    const newNamespace = 'test-namespace';
+
+    await uiHelper.verifyHeading('Software Templates');
+    await uiHelper.clickBtnInCard('Create a kubernetes namespace', 'Choose');
+    await uiHelper.waitForTitle('Create a kubernetes namespace', 2);
+
+    await page.getByLabel('Namespace name').fill(newNamespace);
+    await page.getByLabel('Url').fill(process.env.K8S_CLUSTER_URL);
+    await page.getByLabel('Token').fill(process.env.K8S_CLUSTER_TOKEN);
+    await page.getByRole('button', { name: 'Review' }).click();
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    exec(
+      `oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}"`,
+      error => {
+        if (error) {
+          throw new Error('Unable to login to Kubernetes cluster');
+        }
+      },
+    );
+
+    exec(`oc get namespace ${newNamespace}`, error => {
+      if (error) {
+        throw new Error('Namespace not created');
+      }
+    });
+
+    exec(`oc delete namespace ${newNamespace}`, error => {
+      if (error) {
+        throw new Error('Unable to clean up namespace');
+      }
+    });
+  });
+});

--- a/e2e-tests/playwright/support/pageObjects/global-obj.ts
+++ b/e2e-tests/playwright/support/pageObjects/global-obj.ts
@@ -15,6 +15,8 @@ export const UIhelperPO = {
   MuiButtonTextPrimary: '.MuiButton-textPrimary',
   MuiCard: cardHeading =>
     `//div[contains(@class,'MuiCardHeader-root') and descendant::*[text()='${cardHeading}']]/..`,
+  MuiCardRoot: cardText =>
+    `//div[contains(@class,'MuiCard-root') and descendant::*[text()='${cardText}']]/..`,
   MuiTable: 'table.MuiTable-root',
   MuiCardHeader: 'div[class*="MuiCardHeader-root"]',
   MuiInputBase: 'div[class*="MuiInputBase-root"]',

--- a/e2e-tests/playwright/utils/UIhelper.ts
+++ b/e2e-tests/playwright/utils/UIhelper.ts
@@ -239,8 +239,8 @@ export class UIhelper {
     await expect(headingLocator).toBeVisible();
   }
 
-  async waitForH4Title(text: string) {
-    await this.page.waitForSelector(`h4:has-text("${text}")`, {
+  async waitForTitle(text: string, level: number = 1) {
+    await this.page.waitForSelector(`h${level}:has-text("${text}")`, {
       timeout: 99999,
     });
   }
@@ -350,6 +350,14 @@ export class UIhelper {
       .first();
     await link.scrollIntoViewIfNeeded();
     await expect(link).toBeVisible();
+  }
+
+  async clickBtnInCard(cardText: string, btnText: string, exact = true) {
+    const card = this.page.locator(UIhelperPO.MuiCardRoot(cardText)).first();
+    await card
+      .getByRole('button', { name: btnText, exact: exact })
+      .first()
+      .click();
   }
 
   async verifyTextinCard(


### PR DESCRIPTION
## Description

Introduces kubernetes-actions e2e test to create Kubernetes namespace

## Which issue(s) does this PR fix

- Fixes [RHIDP-1000](https://issues.redhat.com/browse/RHIDP-1000)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Still left to do:
- add test using clusterRef
- either add wrapper for kubernetes-actions or temporarily use `@dzemanov/dynamic-plugins-kubernetes-actions`
