### PR TITLE
fix(CVE): explicitly remove body-parser 1.20.2 in favour of 1.20.3 (RHIDP-3917)

### DIFF
--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/package.json
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "body-parser": "^1.20.2",
+    "body-parser": "^1.20.3",
     "express": "^4.17.3",
     "express-promise-router": "^4.1.0",
     "http-proxy-middleware": "^2.0.6",

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/yarn.lock
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/yarn.lock
@@ -76,7 +76,7 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
-body-parser@1.20.3:
+body-parser@^1.20.2, body-parser@1.20.3:
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
   integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==

--- a/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/yarn.lock
+++ b/dynamic-plugins/wrappers/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic/dist-dynamic/yarn.lock
@@ -94,24 +94,6 @@ body-parser@1.20.3:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@^1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
-  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.5"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.11.0"
-    raw-body "2.5.2"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
 braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"


### PR DESCRIPTION
### What does this PR do?

fix(CVE): explicitly remove body-parser 1.20.2 in favour of 1.20.3 ([RHIDP-3917](https://issues.redhat.com//browse/RHIDP-3917))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.