### PR TITLE
Refactor namespace deletion logic and add finalizer removal.

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -89,12 +89,28 @@ uninstall_helmchart() {
 
 configure_namespace() {
   local project=$1
-  if oc get namespace "${project}" >/dev/null 2>&1; then
-    echo "Namespace ${project} already exists! refreshing namespace"
-    oc delete namespace "${project}"
-  fi
+  delete_namespace $project
   oc create namespace "${project}"
   oc config set-context --current --namespace="${project}"
+}
+
+delete_namespace() {
+  local project=$1
+  if oc get namespace "$project" >/dev/null 2>&1; then
+    echo "Namespace ${project} exists. Attempting to delete..."
+
+    # Remove blocking finalizers
+    remove_finalizers_from_resources "$project"
+
+    # Attempt to delete the namespace
+    oc delete namespace "$project" --grace-period=0 --force || true
+
+    # Check if namespace is still stuck in 'Terminating' and force removal if necessary
+    if oc get namespace "$project" -o jsonpath='{.status.phase}' | grep -q 'Terminating'; then
+      echo "Namespace ${project} is stuck in Terminating. Forcing deletion..."
+      force_delete_namespace "$project"
+    fi
+  fi
 }
 
 configure_external_postgres_db() {
@@ -298,6 +314,33 @@ check_and_test() {
     OVERALL_RESULT=1
   fi
   save_all_pod_logs $namespace
+}
+
+# Function to remove finalizers from specific resources in a namespace that are blocking deletion.
+remove_finalizers_from_resources() {
+  local project=$1
+  echo "Removing finalizers from resources in namespace ${project} that are blocking deletion."
+
+  # Remove finalizers from stuck PipelineRuns and TaskRuns
+  for resource_type in "pipelineruns.tekton.dev" "taskruns.tekton.dev"; do
+    for resource in $(oc get "$resource_type" -n "$project" -o name); do
+      oc patch "$resource" -n "$project" --type='merge' -p '{"metadata":{"finalizers":[]}}' || true
+      echo "Removed finalizers from $resource in $project."
+    done
+  done
+
+  # Check and remove specific finalizers stuck on 'chains.tekton.dev' resources
+  for chain_resource in $(oc get pipelineruns.tekton.dev,taskruns.tekton.dev -n "$project" -o name); do
+    oc patch "$chain_resource" -n "$project" --type='json' -p='[{"op": "remove", "path": "/metadata/finalizers"}]' || true
+    echo "Removed Tekton finalizers from $chain_resource in $project."
+  done
+}
+
+# Function to forcibly delete a namespace stuck in 'Terminating' status
+force_delete_namespace() {
+  local project=$1
+  echo "Forcefully deleting namespace ${project}."
+  oc get namespace "$project" -o json | jq '.spec = {"finalizers":[]}' | oc replace --raw "/api/v1/namespaces/$project/finalize" -f -
 }
 
 main() {


### PR DESCRIPTION
Refactor `configure_namespace` by extracting namespace deletion into a new function `delete_namespace`. Introduce functions to remove blocking finalizers and forcibly delete namespaces stuck in 'Terminating' status. This improves reliability and handling of namespace deletions in the OpenShift CI pipeline.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4752](https://issues.redhat.com/browse/RHIDP-4752)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
