### PR TITLE
chore(e2e): use a fixed digit of SHORT_SHA for image name

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get the last commit short SHA
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           if [[ -f packages/app/src/build-metadata.json ]]; then
             repo="${{ github.repository }}"

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get the last commit short SHA of the PR
         run: |
-          SHORT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          SHORT_SHA=$(git rev-parse --short=8 ${{ github.event.pull_request.head.sha }})
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           if [[ -f packages/app/src/build-metadata.json ]]; then
             repoPR="${{ github.repository }}/pull/${{ github.event.number }}"


### PR DESCRIPTION
## Description

To have consistent image names with SHORT_SHA as a suffix, use  `git rev-parse --short=8`. Otherwise, we would get inconsistent number of digits from the command.  

## Which issue(s) does this PR fix

- Fixes [RHIDP-4775](https://issues.redhat.com/browse/RHIDP-4775)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
