### PR TITLE
test(e2e): deleting pointless assertion for "Verify all 12 Software Templates appear in the Create page" test

### DIFF
--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -71,7 +71,6 @@ test.describe.serial("GitHub Happy path", () => {
   test("Verify all 12 Software Templates appear in the Create page", async () => {
     await uiHelper.openSidebar("Create...");
     await uiHelper.verifyHeading("Templates");
-    await uiHelper.waitForHeaderTitle();
 
     for (const template of templates) {
       await uiHelper.waitForH4Title(template);


### PR DESCRIPTION
## Description

At the test under github happy path: "Verify all 12 Software Templates appear in the Create page", there is an assertion waiting for a title which is already waited and validated on the previous line.
Keeping this step does not add any stability, nor validates anything in the test, and is now causing the test to fail due to the selector resolving to 2 frontend elements.

Example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/janus-idp_backstage-showcase/1869/pull-ci-janus-idp-backstage-showcase-main-e2e-tests/1853815613202370560/artifacts/e2e-tests/janus-idp-backstage-showcase/artifacts/showcase/trace/index.html?trace=https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/janus-idp_backstage-showcase/1869/pull-ci-janus-idp-backstage-showcase-main-e2e-tests/1853815613202370560/artifacts/e2e-tests/janus-idp-backstage-showcase/artifacts/showcase/data/f7973107c6affda169ed6655d5f91a3344b2e5d7.zip


## Which issue(s) does this PR fix

hotfix, does not have a ticket

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
