### PR TITLE
chore(docker): exclude dynamic-plugins-root/...

### DIFF
--- a/scripts/update-Dockerfile.sh
+++ b/scripts/update-Dockerfile.sh
@@ -14,7 +14,7 @@ for dockerfile in ./docker/Dockerfile .rhdh/docker/Dockerfile; do
   # trim existing COPY lines
   sed -i "/# BEGIN COPY package.json files/,/# END COPY package.json files/c# BEGIN COPY package.json files\n# END COPY package.json files" $dockerfile
   # add new COPY lines
-  for path in $(find . -name package.json | grep -v node_modules/ | sort -uV); do
+  for path in $(find . -name package.json | grep -E -v "node_modules/|dynamic-plugins-root/" | sort -uV); do
     sed -i "s|\# BEGIN COPY package.json files|\# BEGIN COPY package.json files\nCOPY ${path/\./\$EXTERNAL_SOURCE_NESTED} $path|g" $dockerfile
   done
 done


### PR DESCRIPTION
### What does this PR do?

chore(docker): exclude dynamic-plugins-root/ paths from the list of COPY commands in the dockerfile

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.