### PR TITLE
chore(docker): ensure yarn is on the path (RHIDP-4211)

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -46,8 +46,8 @@ WORKDIR $CONTAINER_SOURCE/
 COPY $EXTERNAL_SOURCE_NESTED/.yarn ./.yarn
 COPY $EXTERNAL_SOURCE_NESTED/.yarnrc.yml ./
 
-# Add execute permissions to yarn
-RUN chmod +x "$YARN"
+# Add execute permissions to yarn; add yarn to path via symlink
+RUN chmod +x "$YARN" && ln -s "$YARN" /usr/local/bin/yarn
 
 # Stage 2 - Install dependencies
 COPY $EXTERNAL_SOURCE_NESTED/yarn.lock ./
@@ -215,10 +215,7 @@ RUN \
   # debug
   # ls -l /usr/; \
   # set up node dir with common.gypi and unsafe-perms=true
-  ln -s /usr/include/node/common.gypi /usr/common.gypi; "$YARN" config set nodedir /usr; "$YARN" config set unsafe-perm true; \
-  \
-  # add yarn to path via symlink
-  ln -s "$CONTAINER_SOURCE"/"$YARN" /usr/local/bin/yarn
+  ln -s /usr/include/node/common.gypi /usr/common.gypi; "$YARN" config set nodedir /usr; "$YARN" config set unsafe-perm true
 
 # Downstream only - debug
 # RUN echo $PATH; ls -la /usr/local/bin/yarn; whereis yarn;which yarn; yarn --version; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,8 +46,8 @@ WORKDIR $CONTAINER_SOURCE/
 COPY $EXTERNAL_SOURCE_NESTED/.yarn ./.yarn
 COPY $EXTERNAL_SOURCE_NESTED/.yarnrc.yml ./
 
-# Add execute permissions to yarn
-RUN chmod +x "$YARN"
+# Add execute permissions to yarn; add yarn to path via symlink
+RUN chmod +x "$YARN" && ln -s "$YARN" /usr/local/bin/yarn
 
 # Stage 2 - Install dependencies
 FROM skeleton AS deps


### PR DESCRIPTION
### What does this PR do?

chore(docker): ensure yarn is on the path so we can refer to it inside package.json files
this fix is for downstream but might as well do the same for upstream for now to be consistent

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-4211

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.