### PR TITLE
Skip Tekton plugin tests and comment out pipeline setup

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -21,7 +21,7 @@ source "${DIR}/utils.sh"
 set_cluster_info() {
   export K8S_CLUSTER_URL=$(cat /tmp/secrets/RHDH_PR_OS_CLUSTER_URL)
   export K8S_CLUSTER_TOKEN=$(cat /tmp/secrets/RHDH_PR_OS_CLUSTER_TOKEN)
-  
+
   if [[ "$JOB_NAME" == *ocp-v4-14 ]]; then
     K8S_CLUSTER_URL=$(cat /tmp/secrets/RHDH_OS_1_CLUSTER_URL)
     K8S_CLUSTER_TOKEN=$(cat /tmp/secrets/RHDH_OS_1_CLUSTER_TOKEN)
@@ -148,9 +148,9 @@ apply_yaml_files() {
   oc apply -f "$dir/resources/config_map/configmap-rbac-policy-rhdh.yaml" --namespace="${project}"
   oc apply -f "$dir/auth/secrets-rhdh-secrets.yaml" --namespace="${project}"
 
-  sleep 20 # wait for Pipeline Operator to be ready
-  oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline.yaml"
-  oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline-run.yaml"
+  #sleep 20 # wait for Pipeline Operator to be ready
+  #oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline.yaml"
+  #oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline-run.yaml"
 }
 
 run_tests() {
@@ -239,7 +239,7 @@ install_pipelines_operator() {
 
 initiate_deployments() {
   configure_namespace "${NAME_SPACE}"
-  install_pipelines_operator "${DIR}"
+  #install_pipelines_operator "${DIR}"
   install_helm
   uninstall_helmchart "${NAME_SPACE}" "${RELEASE_NAME}"
 
@@ -250,7 +250,7 @@ initiate_deployments() {
   helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE}" "${HELM_REPO_NAME}/${HELM_IMAGE_NAME}" --version "${CHART_VERSION}" -f "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" --set global.clusterRouterBase="${K8S_CLUSTER_ROUTER_BASE}" --set upstream.backstage.image.repository="${QUAY_REPO}" --set upstream.backstage.image.tag="${TAG_NAME}"
 
   configure_namespace "${NAME_SPACE_RBAC}"
-  install_pipelines_operator "${DIR}"
+  #install_pipelines_operator "${DIR}"
   uninstall_helmchart "${NAME_SPACE_RBAC}" "${RELEASE_NAME_RBAC}"
   apply_yaml_files "${DIR}" "${NAME_SPACE_RBAC}"
   echo "Deploying image from repository: ${QUAY_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE : ${RELEASE_NAME_RBAC}"

--- a/e2e-tests/playwright/e2e/plugins/tekton/tekton.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/tekton/tekton.spec.ts
@@ -9,7 +9,7 @@ import { Tekton } from '../../../utils/tekton/tekton';
 // Pre-req: A kubernetes cluster containing pipeline and pipelinerun resources labeled with backstage.io/kubernetes-id: developer-hub
 // Pre-req: A catalog entity with the matching backstage.io/kubernetes-id: developer-hub annotation as well as the janus-idp.io/tekton : <BACKSTAGE_ENTITY_NAME> annotation
 
-test.describe('Test Tekton plugin', () => {
+test.describe.skip('Test Tekton plugin', () => {
   let common: Common;
   let uiHelper: UIhelper;
   let tekton: Tekton;


### PR DESCRIPTION
Disable Tekton plugin tests by adding `test.describe.skip`. Also, comment out pipeline setup commands in the OpenShift CI script, including steps to install the pipelines operator and apply pipeline configuration.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
