### PR TITLE
chore(keycloak): update export-dynamic command

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/dist-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/dist-dynamic/package.json
@@ -2,7 +2,7 @@
   "name": "backstage-community-plugin-catalog-backend-module-keycloak-dynamic",
   "version": "3.2.1",
   "main": "./dist/index.cjs.js",
-  "types": "src/index.ts",
+  "types": "./dist/index.d.ts",
   "license": "Apache-2.0",
   "private": true,
   "publishConfig": {
@@ -17,19 +17,17 @@
   "exports": {
     ".": {
       "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.cjs.js"
     },
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "24.0.5",
-    "inclusion": "^1.0.1",
-    "lodash": "^4.17.21",
-    "pg-format": "^1.0.4",
-    "uuid": "^9.0.1"
+    "@backstage-community/plugin-catalog-backend-module-keycloak": "3.2.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "embedded"
   ],
   "repository": {
     "type": "git",
@@ -47,18 +45,19 @@
     "lifecycle:active"
   ],
   "bundleDependencies": true,
-  "peerDependencies": {
-    "@backstage/backend-plugin-api": "^1.0.1",
-    "@backstage/catalog-model": "^1.7.0",
-    "@backstage/errors": "^1.2.4",
-    "@backstage/plugin-catalog-node": "^1.13.1"
-  },
   "overrides": {
     "@aws-sdk/util-utf8-browser": {
       "@smithy/util-utf8": "^2.0.0"
     }
   },
   "resolutions": {
-    "@aws-sdk/util-utf8-browser": "npm:@smithy/util-utf8@~2"
+    "@aws-sdk/util-utf8-browser": "npm:@smithy/util-utf8@~2",
+    "@backstage-community/plugin-catalog-backend-module-keycloak": "file:./embedded/backstage-community-plugin-catalog-backend-module-keycloak"
+  },
+  "peerDependencies": {
+    "@backstage/backend-plugin-api": "^1.0.1",
+    "@backstage/catalog-model": "^1.7.0",
+    "@backstage/errors": "^1.2.4",
+    "@backstage/plugin-catalog-node": "^1.13.1"
   }
 }

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/dist-dynamic/yarn.lock
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/dist-dynamic/yarn.lock
@@ -5,6 +5,24 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@backstage-community/plugin-catalog-backend-module-keycloak@file:./embedded/backstage-community-plugin-catalog-backend-module-keycloak::locator=backstage-community-plugin-catalog-backend-module-keycloak-dynamic%40workspace%3A.":
+  version: 3.2.1+embedded
+  resolution: "@backstage-community/plugin-catalog-backend-module-keycloak@file:./embedded/backstage-community-plugin-catalog-backend-module-keycloak#./embedded/backstage-community-plugin-catalog-backend-module-keycloak::hash=27b95d&locator=backstage-community-plugin-catalog-backend-module-keycloak-dynamic%40workspace%3A."
+  dependencies:
+    "@keycloak/keycloak-admin-client": 24.0.5
+    inclusion: ^1.0.1
+    lodash: ^4.17.21
+    pg-format: ^1.0.4
+    uuid: ^9.0.1
+  peerDependencies:
+    "@backstage/backend-plugin-api": ^1.0.1
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-catalog-node": ^1.13.1
+  checksum: 17e096e9018dce0bd69976a9089c8da042d0d5b578e5aaa6999958bdfe0c3c1b4a55f55e6905f668fa27496d2ec699a170179e6497c9d19b1472ee29e55f76b8
+  languageName: node
+  linkType: hard
+
 "@keycloak/keycloak-admin-client@npm:24.0.5":
   version: 24.0.5
   resolution: "@keycloak/keycloak-admin-client@npm:24.0.5"
@@ -20,11 +38,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-keycloak-dynamic@workspace:."
   dependencies:
-    "@keycloak/keycloak-admin-client": 24.0.5
-    inclusion: ^1.0.1
-    lodash: ^4.17.21
-    pg-format: ^1.0.4
-    uuid: ^9.0.1
+    "@backstage-community/plugin-catalog-backend-module-keycloak": 3.2.1
   peerDependencies:
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/catalog-model": ^1.7.0

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
@@ -32,8 +32,8 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-catalog-backend-module-keycloak --override-interop default --no-embed-as-dependencies",
-    "export-dynamic:clean": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-catalog-backend-module-keycloak --override-interop default --no-embed-as-dependencies --clean"
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-catalog-backend-module-keycloak --override-interop default",
+    "export-dynamic:clean": "janus-cli package export-dynamic-plugin --embed-package @backstage-community/plugin-catalog-backend-module-keycloak --override-interop default --clean"
   },
   "dependencies": {
     "@backstage-community/plugin-catalog-backend-module-keycloak": "3.2.1"
@@ -46,7 +46,8 @@
   "files": [
     "dist",
     "dist-dynamic/*.*",
-    "dist-dynamic/dist/**"
+    "dist-dynamic/dist/**",
+    "embedded"
   ],
   "repository": {
     "type": "git",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic/package.json
@@ -13,6 +13,7 @@
     "supported-versions": "1.32.5",
     "pluginId": "red-hat-developer-hub-backstage-plugin-bulk-import-backend",
     "pluginPackages": [
+      "red-hat-developer-hub-backstage-plugin-bulk-import",
       "red-hat-developer-hub-backstage-plugin-bulk-import-backend"
     ]
   },

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/package.json
@@ -14,7 +14,8 @@
     "supported-versions": "1.32.5",
     "pluginId": "red-hat-developer-hub-backstage-plugin-bulk-import-backend",
     "pluginPackages": [
-      "red-hat-developer-hub-backstage-plugin-bulk-import"
+      "red-hat-developer-hub-backstage-plugin-bulk-import",
+      "red-hat-developer-hub-backstage-plugin-bulk-import-backend"
     ]
   },
   "sideEffects": false,


### PR DESCRIPTION
## Description

This PR removes the `--no-embed-as-dependencies` flag from the keycloak wrapper's export-dynamic command.


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
