### PR TITLE
test(e2e): disable a flaky test temporarily:  catalog-entity refresh is denied after DELETE

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac-api.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac-api.spec.ts
@@ -238,7 +238,7 @@ test.describe("Test RBAC plugin REST API", () => {
     expect(deleteResponse.ok());
   });
 
-  test("Test catalog-entity refresh is denied after DELETE", async () => {
+  test.skip("Test catalog-entity refresh is denied after DELETE", async () => {
     await uiHelper.openSidebar("Catalog");
     await uiHelper.selectMuiBox("Kind", "API");
     await uiHelper.clickLink("Nexus Repo Manager 3");


### PR DESCRIPTION
## Description

Disable a flaky test in order to unblock other PRs. A separate issue will be opened to re-enable the test. 

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-4775

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
