### PR TITLE
chore(e2e): rhidp-4958 re-enable the flaky test - catalog-entity refresh is denied after DELETE

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac-api.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac-api.spec.ts
@@ -10,9 +10,13 @@ test.describe("Test RBAC plugin REST API", () => {
   let uiHelper: UIhelper;
   let page: Page;
   let responseHelper: Response;
+  // Variable to track errors or test states
+  let hasErrors = false;
+  let retriesRemaining: number;
 
   test.beforeAll(async ({ browser }, testInfo) => {
     page = (await setupBrowser(browser, testInfo)).page;
+    retriesRemaining = testInfo.project.retries;
 
     uiHelper = new UIhelper(page);
     common = new Common(page);
@@ -23,9 +27,12 @@ test.describe("Test RBAC plugin REST API", () => {
     responseHelper = new Response(apiToken);
   });
 
-  test.beforeEach(
-    async () => await new Common(page).checkAndClickOnGHloginPopup(),
-  );
+  // eslint-disable-next-line no-empty-pattern
+  test.beforeEach(async ({}, testInfo) => {
+    console.log(
+      `beforeEach: Attempting setup for ${testInfo.title}, retry: ${testInfo.retry}`,
+    );
+  });
 
   test("Test that roles and policies from GET request are what expected", async ({
     request,
@@ -238,16 +245,38 @@ test.describe("Test RBAC plugin REST API", () => {
     expect(deleteResponse.ok());
   });
 
-  test.skip("Test catalog-entity refresh is denied after DELETE", async () => {
+  test("Test catalog-entity refresh is denied after DELETE", async () => {
     await uiHelper.openSidebar("Catalog");
     await uiHelper.selectMuiBox("Kind", "API");
     await uiHelper.clickLink("Nexus Repo Manager 3");
     expect(await uiHelper.isBtnVisible("Schedule entity refresh")).toBeFalsy();
   });
 
-  test.afterAll(
-    "Cleanup by deleting all new policies and roles",
-    async ({ request }) => {
+  // eslint-disable-next-line no-empty-pattern
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === "failed") {
+      console.log(`Test failed: ${testInfo.title}`);
+      hasErrors = true;
+
+      // Calculate the remaining retries by subtracting the current retry count from the total retries and adjusting for zero-based indexing.
+      retriesRemaining = testInfo.project.retries - testInfo.retry - 1;
+      console.log(`Retries remaining: ${retriesRemaining}`);
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (hasErrors && retriesRemaining > 0) {
+      console.log(
+        `Skipping cleanup due to errors. Retries remaining: ${retriesRemaining}`,
+      );
+      return;
+    }
+
+    console.log(
+      `afterAll: Proceeding with cleanup. Retries remaining: ${retriesRemaining}`,
+    );
+
+    try {
       const remainingPoliciesResponse = await request.get(
         "/api/permission/policies/role/default/test",
         responseHelper.getSimpleRequest(),
@@ -267,8 +296,10 @@ test.describe("Test RBAC plugin REST API", () => {
         responseHelper.getSimpleRequest(),
       );
 
-      expect(deleteRemainingPolicies.ok());
-      expect(deleteRole.ok());
-    },
-  );
+      expect(deleteRemainingPolicies.ok()).toBeTruthy();
+      expect(deleteRole.ok()).toBeTruthy();
+    } catch (error) {
+      console.error("Error during cleanup in afterAll:", error);
+    }
+  });
 });

--- a/e2e-tests/playwright/support/pages/rbac.ts
+++ b/e2e-tests/playwright/support/pages/rbac.ts
@@ -294,13 +294,31 @@ export class Response {
     };
   }
 
-  async removeMetadataFromResponse(response: APIResponse) {
-    const responseJson = await response.json();
-    const responseClean = responseJson.map((list: any) => {
-      delete list.metadata;
-      return list;
-    });
-    return responseClean;
+  async removeMetadataFromResponse(response: APIResponse): Promise<any[]> {
+    try {
+      const responseJson = await response.json();
+
+      // Validate that the response is an array
+      if (!Array.isArray(responseJson)) {
+        console.warn(
+          `Expected an array but received: ${JSON.stringify(responseJson)}`,
+        );
+        return []; // Return an empty array as a fallback
+      }
+
+      // Clean metadata from the response
+      const responseClean = responseJson.map((item: any) => {
+        if (item.metadata) {
+          delete item.metadata;
+        }
+        return item;
+      });
+
+      return responseClean;
+    } catch (error) {
+      console.error("Error processing API response:", error);
+      throw new Error("Failed to process the API response");
+    }
   }
 
   async checkResponse(response: APIResponse, expected: string) {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHIDP-4958

Added error tracking and logging to beforeEach, afterEach, and afterAll hooks to improve robustness and clarity. Skipped cleanup actions if errors occurred during retries to avoid inconsistent state.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
