### PR TITLE
chore(e2e): reenable scaffolder-backend-module-http-request test

### DIFF
--- a/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -120,6 +120,12 @@ proxy:
         Authorization: '${ACR_SECRET}'
       # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
       secure: false
+    '/quay/api':
+      target: https://quay.io/
+      headers:
+        X-Requested-With: 'XMLHttpRequest'
+      changeOrigin: true
+      secure: true
 catalog:
   import:
     entityFilename: catalog-info.yaml

--- a/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
@@ -7,39 +7,36 @@ import { CatalogImport } from "../../support/pages/CatalogImport";
 // Pre-req: Enable roadiehq-scaffolder-backend-module-http-request-dynamic plugin
 // Pre-req: Enable janus-idp-backstage-plugin-quay plugin
 //TODO Re-enable when roadiehq-scaffolder-backend-module-http-request-dynamic is included in the Helm image
-test.describe.skip(
-  "Testing scaffolder-backend-module-http-request to invoke an external request",
-  () => {
-    let uiHelper: UIhelper;
-    let common: Common;
-    let catalogImport: CatalogImport;
-    const template =
-      "https://github.com/janus-qe/software-template/blob/main/test-http-request.yaml";
+test.describe("Testing scaffolder-backend-module-http-request to invoke an external request", () => {
+  let uiHelper: UIhelper;
+  let common: Common;
+  let catalogImport: CatalogImport;
+  const template =
+    "https://github.com/janus-qe/software-template/blob/main/test-http-request.yaml";
 
-    test.beforeEach(async ({ page }) => {
-      uiHelper = new UIhelper(page);
-      common = new Common(page);
-      await common.loginAsGuest();
-      catalogImport = new CatalogImport(page);
-    });
+  test.beforeEach(async ({ page }) => {
+    uiHelper = new UIhelper(page);
+    common = new Common(page);
+    await common.loginAsGuest();
+    catalogImport = new CatalogImport(page);
+  });
 
-    test("Create a software template using http-request plugin", async () => {
-      await uiHelper.openSidebar("Create...");
-      await uiHelper.verifyHeading("Templates");
-      await uiHelper.waitForHeaderTitle();
-      await uiHelper.clickButton("Register Existing Component");
-      await catalogImport.registerExistingComponent(template);
+  test("Create a software template using http-request plugin", async () => {
+    await uiHelper.openSidebar("Create...");
+    await uiHelper.verifyHeading("Templates");
+    await uiHelper.waitForHeaderTitle();
+    await uiHelper.clickButton("Register Existing Component");
+    await catalogImport.registerExistingComponent(template);
 
-      await uiHelper.openSidebar("Catalog");
-      await uiHelper.selectMuiBox("Kind", "Template");
-      await uiHelper.searchInputPlaceholder("Test");
-      await uiHelper.clickLink("Test HTTP Request");
-      await uiHelper.verifyHeading("Test HTTP Request");
-      await uiHelper.clickLink("Launch Template");
-      await uiHelper.verifyHeading("Software Templates");
-      await uiHelper.clickButton("Create");
-      //Checking for Http Status 200
-      await uiHelper.verifyText("200", false);
-    });
-  },
-);
+    await uiHelper.openSidebar("Catalog");
+    await uiHelper.selectMuiBox("Kind", "Template");
+    await uiHelper.searchInputPlaceholder("Test");
+    await uiHelper.clickLink("Test HTTP Request");
+    await uiHelper.verifyHeading("Test HTTP Request");
+    await uiHelper.clickLink("Launch Template");
+    await uiHelper.verifyHeading("Software Templates");
+    await uiHelper.clickButton("Create");
+    //Checking for Http Status 200
+    await uiHelper.verifyText("200", false);
+  });
+});

--- a/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
@@ -24,7 +24,6 @@ test.describe("Testing scaffolder-backend-module-http-request to invoke an exter
   test("Create a software template using http-request plugin", async () => {
     await uiHelper.openSidebar("Create...");
     await uiHelper.verifyHeading("Templates");
-    await uiHelper.waitForHeaderTitle();
     await uiHelper.clickButton("Register Existing Component");
     await catalogImport.registerExistingComponent(template);
 

--- a/e2e-tests/playwright/utils/UIhelper.ts
+++ b/e2e-tests/playwright/utils/UIhelper.ts
@@ -34,10 +34,6 @@ export class UIhelper {
     await this.page.keyboard.press("Tab");
   }
 
-  async waitForHeaderTitle() {
-    await this.page.waitForSelector('h2[data-testid="header-title"]');
-  }
-
   async clickButton(
     label: string | RegExp,
     options: { exact?: boolean; force?: boolean } = {


### PR DESCRIPTION
## Description

Reenables the scaffolder-backend-module-http-request e2e test that was disabled due to a problem with the dynamic plugin.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4837](https://issues.redhat.com/browse/RHIDP-4837)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
