### PR TITLE
chore(docs): add dynamic plugins examples doc

### DIFF
--- a/docs/dynamic-plugins/examples.md
+++ b/docs/dynamic-plugins/examples.md
@@ -1,0 +1,20 @@
+# Examples
+
+There are several example dynamic plugin projects that have been created to demonstrate various dynamic plugin related features.  Here are some links to externally developed examples for further reference.
+
+> [!WARNING]
+> The following examples are maintained on a best-effort basis, some adjustments may be needed to get an example running, especially against a different target RHDH version.
+
+## For RHDH 1.4 (pre-release)
+
+- [Installing a custom middleware function using a dynamic plugin](https://github.com/gashcrumb/dynamic-plugins-root-http-middleware)
+
+## For RHDH 1.3
+
+- [A dynamic plugin containing a theme](https://github.com/gashcrumb/dynamic-plugins-getting-started-theme)
+
+## For RHDH 1.2
+
+- [A detailed getting started example](https://github.com/gashcrumb/dynamic-plugins-getting-started)
+- [A way to expose a custom mount point from a plugin](https://github.com/gashcrumb/dynamic-plugins-getting-started-custom-mount-point)
+- [A simple example showing how to embed packages](https://github.com/gashcrumb/dynamic-plugins-getting-started-dependency-embedding)

--- a/docs/dynamic-plugins/index.md
+++ b/docs/dynamic-plugins/index.md
@@ -28,6 +28,8 @@ More details about publishing dynamic plugins is in the [Packaging Dynamic Plugi
 
 [Wrapping a third-party backend plugin to add dynamic plugin support](wrapping-plugins.md)
 
+[Examples](examples.md)
+
 ## Installing external Backstage plugins into RHDH
 
 1. Get the source code of the plugin.


### PR DESCRIPTION
## Description

This change adds a document to hold links to examples that have been developed showing either how to use dynamic plugins or show off features that are related to or enabled by dynamic plugins.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4872](https://issues.redhat.com/browse/RHIDP-4872)?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Please request changes with a link for any other examples we would like included in this document.