### PR TITLE
chore(ci): playwright install only chromium

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -261,7 +261,7 @@ run_tests() {
   project=${project%-pr-*} # Remove -pr- suffix if any set for main branchs pr's.
   cd "${DIR}/../../e2e-tests"
   yarn install
-  yarn playwright install
+  yarn playwright install chromium
 
   Xvfb :99 &
   export DISPLAY=:99

--- a/docs/e2e-tests/README.md
+++ b/docs/e2e-tests/README.md
@@ -29,7 +29,7 @@ yarn install
 The Playwright browsers should be installed automatically via the `postinstall` script in `package.json`. If not, you can manually install them:
 
 ```bash
-yarn playwright install
+yarn playwright install chromium
 ```
 
 ### Adding a Test


### PR DESCRIPTION
## Description

In the e2e tests setup, we are installing Chromium, Firefox, and Webkit, but we only run tests on Chromium. This is unnecessary, slows down the process, and produces unintended traffic. This PR edits the tests setup that we only install Chromium and its dependencies.

## Which issue(s) does this PR fix

- Fixes [RHIDP-5047](https://issues.redhat.com/browse/RHIDP-5047)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
