### PR TITLE
chore(ci): disable `droute` until outage is resolved

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -290,7 +290,8 @@ run_tests() {
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
   cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
 
-  droute_send "${release_name}" "${project}"
+  # TODO Re-enable `droute` once outage is resolved
+  # droute_send "${release_name}" "${project}"
 
   echo "${project} RESULT: ${RESULT}"
   if [ "${RESULT}" -ne 0 ]; then


### PR DESCRIPTION
## Description

There is an outage impacting Data Router that prevents us from downloading `droute`
- https://redhat-internal.slack.com/archives/C06Q4M84XDG/p1732701906050359
- https://redhat-internal.slack.com/archives/C04CUSD4JSG/p1732702296382899

EDIT: Outage has an ETA: 7PM UTC+2 to be resolved.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-5084

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
