### PR TITLE
chore(ci): re-enable `droute` and don't fail on pull requests

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -289,8 +289,7 @@ run_tests() {
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
   cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
 
-  # TODO Re-enable `droute` once outage is resolved
-  # droute_send "${release_name}" "${project}"
+  droute_send "${release_name}" "${project}"
 
   echo "${project} RESULT: ${RESULT}"
   if [ "${RESULT}" -ne 0 ]; then

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -39,6 +39,9 @@ save_all_pod_logs(){
 droute_send() {
   temp_kubeconfig=$(mktemp) # Create temporary KUBECONFIG to open second `oc` session
   ( # Open subshell
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      set +e
+    fi
     export KUBECONFIG="$temp_kubeconfig"
     local droute_version="1.2.2"
     local release_name=$1
@@ -159,6 +162,9 @@ droute_send() {
       set -e
     fi
     oc exec -n "${droute_project}" "${droute_pod_name}" -- /bin/bash -c "rm -rf ${temp_droute}/*"
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      set -e
+    fi
   ) # Close subshell
   rm -f "$temp_kubeconfig" # Destroy temporary KUBECONFIG
   oc whoami --show-server


### PR DESCRIPTION
## Description

- Re-enable Data Router (`droute`) after the outage got resolved.
- Add an exception to don't fail the PR check if only `droute` failed. That way, `droute` failure would only fail the nightly jobs. 

## Which issue(s) does this PR fix

- Fixes [issues.redhat.com/browse/RHIDP-5084](https://issues.redhat.com/browse/RHIDP-5084)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
