### PR TITLE
chore(ci): revert: re-enable `droute` and don't fail on pull requests (#2012)

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -289,7 +289,8 @@ run_tests() {
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
   cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
 
-  droute_send "${release_name}" "${project}"
+  # TODO Re-enable `droute` once outage is resolved
+  # droute_send "${release_name}" "${project}"
 
   echo "${project} RESULT: ${RESULT}"
   if [ "${RESULT}" -ne 0 ]; then

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -39,9 +39,6 @@ save_all_pod_logs(){
 droute_send() {
   temp_kubeconfig=$(mktemp) # Create temporary KUBECONFIG to open second `oc` session
   ( # Open subshell
-    if [ -n "${PULL_NUMBER:-}" ]; then
-      set +e
-    fi
     export KUBECONFIG="$temp_kubeconfig"
     local droute_version="1.2.2"
     local release_name=$1
@@ -162,9 +159,6 @@ droute_send() {
       set -e
     fi
     oc exec -n "${droute_project}" "${droute_pod_name}" -- /bin/bash -c "rm -rf ${temp_droute}/*"
-    if [ -n "${PULL_NUMBER:-}" ]; then
-      set -e
-    fi
   ) # Close subshell
   rm -f "$temp_kubeconfig" # Destroy temporary KUBECONFIG
   oc whoami --show-server


### PR DESCRIPTION
## Description

This reverts commit 07af50efe8041e75037c7f85ab555d6dc2b664ff

For me, it looks like the change `set -e` let our CI fail with:

```
[2024-11-28 16:26:09] initiate_deployments
./.ibm/pipelines/openshift-ci-tests.sh: line 55: initiate_deployments: command not found
```

Failing job:

* https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/janus-idp_backstage-showcase/1992/pull-ci-janus-idp-backstage-showcase-main-e2e-tests/1862167944516079616

Let see if other jobs fails on main and if this passes (alone)...

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
