### PR TITLE
fix: add mui v5 workaround in wrapper code

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-acr/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-acr/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-acr';
 

--- a/dynamic-plugins/wrappers/backstage-community-plugin-jfrog-artifactory/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-jfrog-artifactory/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-jfrog-artifactory';
 

--- a/dynamic-plugins/wrappers/backstage-community-plugin-nexus-repository-manager/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-nexus-repository-manager/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-nexus-repository-manager';

--- a/dynamic-plugins/wrappers/backstage-community-plugin-ocm/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-ocm/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-ocm';

--- a/dynamic-plugins/wrappers/backstage-community-plugin-quay/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-quay/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-quay';
 

--- a/dynamic-plugins/wrappers/backstage-community-plugin-rbac/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-rbac/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-rbac';

--- a/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-redhat-argocd';
 

--- a/dynamic-plugins/wrappers/backstage-community-plugin-tekton/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-tekton/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-tekton';
 

--- a/dynamic-plugins/wrappers/backstage-community-plugin-topology/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-topology/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage-community/plugin-topology';

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage/plugin-notifications';

--- a/dynamic-plugins/wrappers/backstage-plugin-signals/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@backstage/plugin-signals';

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/src/index.ts
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+});
+
 export * from '@red-hat-developer-hub/backstage-plugin-bulk-import';
 

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/src/index.ts
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/src/index.ts
@@ -1,2 +1,10 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+})
+
 export * from '@red-hat-developer-hub/backstage-plugin-dynamic-home-page';
 


### PR DESCRIPTION
## Description

Big thanks and kudos to @gashcrumb who solved the issue https://github.com/janus-idp/backstage-plugins/pull/2183 for dynamic plugins with a comment. But it needs to be applied to all plugins.

I'm adding this here now (also with respect to the 1.4 timeline) to these frontend plugins that allowed me to add it.

I would expect that a better solution is to automatically apply this rule when bundling a plugin! But for me the code looks save to be called twice and I'm fine to revert this in 1.4 or 1.5 as soon as we're sure that we include this somewhere else. Tbc. and tbd.  :smirk: 

## Which issue(s) does this PR fix

This fixes at least our ad-hoc issues with Bulk import and RBAC.

* https://issues.redhat.com/browse/RHIDP-5104 Bulk import layout issues with MUI v5 components (missing gaps)

## Changes / Verification

I tested these plugins and compared `next` with this PR on a cluster.

* [x] ACR (MUI v4) => No difference
* [x] Bulk Import (MUI v5 and had issues before) => Issues are solved
* [x] Home page => No difference
* [x] RBAC (MUI v5 and had issues before)
* [x] Tech Radar (MUI v4 afaik) => No difference
* [x] Kubernetes (just because I wanted test Tekton and Topology :D)
* [x] Tekton (PF + MUI v4) => No difference
* [x] Topology (PF + MUI v5 and had issues before that @ciiay fixed in the plugin itself) => no double padding or something. Two small changes: Download log button is now blue and the log dialog uses now 80% instead of 100% of the screen width (both changes lgtm)
* [x] Tech docs => No difference, but unluckily it does not fix the selection bug

Here are the differences (and I think fixes) that I noticed:

### Bulk import

| Area | Before | After |
| --- | --- | --- |
| Bulk import page size selector is fixed | ![image](https://github.com/user-attachments/assets/383e8f14-f46c-44f3-bc3b-2cf04a44893a) | ![image](https://github.com/user-attachments/assets/128365f9-8a48-4a41-80f5-84796b6da523) |
| Padding and collapse icon on the Add repo tutorial is fixed | ![image](https://github.com/user-attachments/assets/506a3536-8bd3-45ac-9858-907f0b217600) | ![image](https://github.com/user-attachments/assets/f93c9c76-681c-49af-aae3-90c424a73139) |
| Repository / Orginzation ToggleButton is fixed | ![image](https://github.com/user-attachments/assets/89bb72b8-045b-4b24-9f7d-a1f5f2469983) | ![image](https://github.com/user-attachments/assets/e8e82130-1f71-4f9c-abe1-827d9993f8bc) |
| Button padding is restored | ![image](https://github.com/user-attachments/assets/3bb3bf11-3c0f-4387-a876-37b83556e914) | ![image](https://github.com/user-attachments/assets/bb7fb3d9-fe9e-41d0-ba22-4cf4c13df32c) |
| Added repository table has no more padding due bigger buttons | ![image](https://github.com/user-attachments/assets/2e6e2f23-c1c3-459e-a6cd-ace190539d1d) | ![image](https://github.com/user-attachments/assets/2f05a727-97b4-48b3-92ba-afb059c2d330) |
| More aligned codeowner button | ![image](https://github.com/user-attachments/assets/d2146d3a-67df-4144-b051-84c3d34eea93) | ![image](https://github.com/user-attachments/assets/e0adaaf8-4fbd-4d5c-a12f-ff6a56f760a4) |

### RBAC

| Area | Before | After |
| --- | --- | --- |
| Download button padding is fixed | ![image](https://github.com/user-attachments/assets/55b6a75a-b1cc-4e58-836a-747cade533fa) | ![image](https://github.com/user-attachments/assets/fa72c277-ea0f-4c52-9ea9-3824ca1cca19) |
| Action buttons have a better padding | ![image](https://github.com/user-attachments/assets/3138ec21-faca-4475-96b2-26d777eb4df0) | ![image](https://github.com/user-attachments/assets/d5b860f5-f624-4fa2-958f-1835c3b84842) |
| Configuration access button has a font color now (I'm hovering it here to show also the background) | ![image](https://github.com/user-attachments/assets/129927e9-aa24-4722-8b35-78783b6d4b9a) | ![image](https://github.com/user-attachments/assets/0abc53c1-e5a5-4dd6-bcf2-9066d2e332ef) |
| Configuration access > Not options has now the right padding | ![image](https://github.com/user-attachments/assets/e844d59a-2371-4c40-8e67-9986d1e31975) | ![image](https://github.com/user-attachments/assets/da3eacae-5a1b-40ec-bace-d9c7c6047c26) |
| Toast X is now better aligned | 
![image](https://github.com/user-attachments/assets/2f140576-d7c0-488b-8b64-4cfa77c5ccbe) | 
![image](https://github.com/user-attachments/assets/8d9f6813-4647-43ae-9c66-11614570fb92) |

/cc @divyanshiGupta @debsmita1 @ShiranHi @ciiay @invincibleJai 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
