### PR TITLE
fix(techdocs): fix ReportIssue style issue when loaded as dynamic plugin

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/ShadowRootStylesProvider.tsx
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/ShadowRootStylesProvider.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import type { StylesOptions } from '@material-ui/styles';
+
+// It's neccessary that this provider is loaded from `core/styles` not just `styles`!
+import { StylesProvider as WrappedStylesProvider, jssPreset } from '@material-ui/core/styles';
+import { create as createJss } from 'jss';
+
+/**
+ * Creates a new JSS StylesProvider that inserts additional styles
+ * to the current (react and browser) dom position.
+ * This is only useful in a shadow root world because MUI v4 component
+ * styles are handled globally.
+ */
+export const ShadowRootStylesProvider = ({ children }: { children: any }) => {
+  const [insertionPoint, setInsertionPoint] = React.useState<HTMLDivElement | null>(null);
+
+  const stylesOptions = React.useMemo<StylesOptions | null>(() => {
+    if (!insertionPoint) {
+      return null;
+    }
+    return {
+      jss: createJss({
+        ...jssPreset(),
+        insertionPoint,
+      }),
+      sheetsManager: new Map(),
+    }
+  }, [insertionPoint])
+
+  return (
+    <div>
+      <div ref={setInsertionPoint}></div>
+      {stylesOptions ? (
+        <WrappedStylesProvider {...stylesOptions}>
+          {children}
+        </WrappedStylesProvider>
+      ) : null}
+    </div>
+  );
+};

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/addons.tsx
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/addons.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { techdocsPlugin } from '@backstage/plugin-techdocs';
+import { createTechDocsAddonExtension, TechDocsAddonLocations } from '@backstage/plugin-techdocs-react';
+
+import { ReportIssue as ReportIssueBase } from "@backstage/plugin-techdocs-module-addons-contrib";
+import { ShadowRootStylesProvider } from './ShadowRootStylesProvider';
+
+/**
+ * Automatically wrap the backstage ReportIssue component with a (JSS)
+ * StylesProvider, the underlaying styling technique under MUI v4.
+ *
+ * With this, the additional styles for overlay button are applied correctly
+ * because the techdocs content is rendered in a shadow root, but the styles
+ * from the ReportIssue components are added to the root document.
+ *
+ * It isn't possible to create an additional shadow root here without reusing
+ * or copying more components from the techdocs packages.
+ *
+ * The addons are rendered with a (react) portal above the content while the
+ * addon itself is added below the content.
+ *
+ * HTML structure:
+ *
+ * html root doc
+ *   backstage sidebar
+ *   backstage header
+ *   techdocs shadow root
+ *     left sidebar (content navigation)
+ *     right sidebar (table of content)
+ *     content
+ *       (report issue link is added here when text is selected)
+ *       content itself
+ *       addons
+ *         report issue wrapper
+ */
+const ReportIssueWrapper = () => {
+  return (
+    <div id="techdocs-report-issue-wrapper">
+      <ShadowRootStylesProvider>
+        <ReportIssueBase />
+      </ShadowRootStylesProvider>
+    </div>
+  );
+};
+
+export const ReportIssue = techdocsPlugin.provide(
+  createTechDocsAddonExtension<{}>({
+    name: 'ReportIssue',
+    location: TechDocsAddonLocations.Content,
+    component: ReportIssueWrapper,
+  }),
+);

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/wrapped.tsx
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/src/wrapped.tsx
@@ -2,7 +2,6 @@ import {
   EntityTechdocsContent as EntityTechdocsContentBase,
   TechDocsReaderPage as TechDocsReaderPageBase,
 } from "@backstage/plugin-techdocs";
-import { ReportIssue } from "@backstage/plugin-techdocs-module-addons-contrib";
 import { TechDocsAddons } from "@backstage/plugin-techdocs-react";
 
 import { SearchFilter, useSearch } from "@backstage/plugin-search-react";
@@ -13,6 +12,8 @@ import {
 } from "@backstage/plugin-catalog-react";
 
 import { useApi } from "@backstage/core-plugin-api";
+
+import { ReportIssue } from "./addons";
 
 export const TechDocsReaderPage = {
   element: TechDocsReaderPageBase,


### PR DESCRIPTION
## Description

Techdocs are rendered in a shadow root so that the backstage theme doesn't affect the rendered content, and the markdown style doesn't affect the backstage app.

The `ReportIssue` techdocs addon requires some additional CSS rules ([for example](https://github.com/backstage/backstage/blob/master/plugins/techdocs-module-addons-contrib/src/ReportIssue/ReportIssue.tsx#L36-L44)), which needs to apply to this shadow root, which also works in a common backstage installation.

But with our dynamic plugins (based on webpack federation) these MUI v4 styles are applied to the root dom via JSS.

This PR adds a workaround to ensure that the styles of the `ReportIssue` components are added within the shadow root element.

It isn't possible to create an additional shadow root here without reusing or copying more components from the techdocs packages.

Because the addons are rendered with a (react) portal above the content while the addon itself is added below the content.

HTML structure:

* html root doc
  * backstage sidebar
  * backstage header
  * techdocs shadow root
    * left sidebar (content navigation)
    * right sidebar (table of content)
    * content
      * (report issue link is added here when text is selected)
      * content itself
      * addons
        * report issue wrapper

**1.4 without this PR:**

https://github.com/user-attachments/assets/e575b239-0311-47b9-b2e1-b3ce72cff2de

**with this PR (tested on a cluster with [pr-2024-912abbd1](https://quay.io/janus-idp/backstage-showcase:pr-2024-912abbd1))**

https://github.com/user-attachments/assets/a12aff96-29ce-47ad-a9bc-91a2886c7042

## Which issue(s) does this PR fix

- Fixes [RHDHBUGS-97](https://issues.redhat.com/browse/RHDHBUGS-97) Bug in text selection in "Docs" section of RHDH
- 1.5 ticket [RHIDP-5119](https://issues.redhat.com/browse/RHIDP-5119) Huge icon when techdoc text is selected, and report a doc issue feature didn't worked [1.5]

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Techdocs is enabled by default.