### PR TITLE
Add UI helper to open sidebar in config map test

### DIFF
--- a/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
+++ b/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { KubeClient } from "../../utils/kube-client";
 import { LOGGER } from "../../utils/logger";
 import { Common } from "../../utils/common";
+import { UIhelper } from "../../utils/ui-helper";
 
 test.describe("Change app-config at e2e test runtime", () => {
   test("Verify title change after ConfigMap modification", async ({ page }) => {
@@ -29,6 +30,7 @@ test.describe("Change app-config at e2e test runtime", () => {
 
       const common = new Common(page);
       await common.loginAsGuest();
+      await new UIhelper(page).openSidebar("Home");
       LOGGER.info("Verifying new title in the UI...");
       expect(await page.title()).toContain(dynamicTitle);
       LOGGER.info("Title successfully verified in the UI.");


### PR DESCRIPTION
Integrated the UIhelper utility to open the "Home" sidebar in the configuration map test. This enhances the test by ensuring the correct UI state before verifying the page title, improving accuracy and reliability.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
