### PR TITLE
chore: modify wrapper tests to include the todo plugin in externalDynamicPlugins

### DIFF
--- a/dynamic-plugins/_utils/src/wrappers.test.ts
+++ b/dynamic-plugins/_utils/src/wrappers.test.ts
@@ -112,11 +112,12 @@ function parseYamlFile<T>(filePath: string): T {
 function validateDynamicPluginsConfig(
   config: DynamicPluginsConfig,
   wrapperDirNames: string[],
-  externalDynamicPlugin?: DynamicPluginConfig,
+  externalDynamicPlugins?: DynamicPluginConfig[],
 ): void {
   const dynamicPluginsPackageNames = config.plugins.reduce(
     (packageNames, plugin) => {
-      if (externalDynamicPlugin?.package !== plugin.package) {
+      const isExternalPlugin = externalDynamicPlugins?.some((externalDynamicPlugin) => externalDynamicPlugin.package === plugin.package)
+      if (!isExternalPlugin) {
         // We want the third index ['.', 'dynamic-plugins', 'dist', 'backstage-plugin-scaffolder-backend-module-github-dynamic']
         packageNames.push(plugin.package.split("/")[3]);
       }
@@ -240,16 +241,20 @@ describe("Dynamic Plugin Wrappers", () => {
       IBM_VALUES_SHOWCASE_CONFIG_FILE,
     );
 
-    const externalDynamicPluginConfig: DynamicPluginConfig = {
+    const externalDynamicPluginsConfig: DynamicPluginConfig[] = [{
       package: "@pataknight/backstage-plugin-rhdh-qe-theme@0.5.5",
       disabled: false,
-    };
+    },
+    {
+      package: "@backstage-community/plugin-todo@0.2.42"
+    }
+  ];
 
     it("should have a corresponding package", () => {
       validateDynamicPluginsConfig(
         config.global.dynamic,
         wrapperDirNames,
-        externalDynamicPluginConfig,
+        externalDynamicPluginsConfig,
       );
     });
   });


### PR DESCRIPTION
## Description

https://github.com/janus-idp/backstage-showcase/pull/2058 adds a new external plugin (@backstage-community/plugin-todo@0.2.42) to `.ibm/pipelines/value_files/values_showcase.yaml`.

This PR modifies the wrapper tests to include `@backstage-community/plugin-todo@0.2.42` in `externalDynamicPluginsConfig` so that the tests exclude this plugin.

Merging this should fix the failing verify wrapper tests in https://github.com/janus-idp/backstage-showcase/pull/2058

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
