### PR TITLE
fix: [e2e-tests] Improve Github popup login used in catalog-scaffoldedfromLink.spec.ts

### DIFF
--- a/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
@@ -37,6 +37,10 @@ test.describe.serial("Link Scaffolded Templates to Catalog Items", () => {
     await common.loginAsGithubUser();
   });
 
+  test.beforeEach(
+    async () => await new Common(page).checkAndClickOnGHloginPopup(),
+  );
+
   test("Register an Template", async () => {
     await uiHelper.openSidebar("Catalog");
     await uiHelper.clickButton("Create");

--- a/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
@@ -37,10 +37,6 @@ test.describe.serial("Link Scaffolded Templates to Catalog Items", () => {
     await common.loginAsGithubUser();
   });
 
-  test.beforeEach(
-    async () => await new Common(page).checkAndClickOnGHloginPopup(),
-  );
-
   test("Register an Template", async () => {
     await uiHelper.openSidebar("Catalog");
     await uiHelper.clickButton("Create");

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -161,21 +161,23 @@ export class Common {
       await frameLocator.waitFor({ state: "visible", timeout: 2000 });
       await this.clickOnGHloginPopup();
     } catch (error) {
-      console.log(JSON.stringify(error))
+      console.log(JSON.stringify(error));
       if (force) throw error;
     }
   }
 
   async clickOnGHloginPopup() {
-    const loginButton = this.page.getByRole('dialog', {name: "Login Required"}).getByRole("button", {name: "Log in"})
+    const loginButton = this.page
+      .getByRole("dialog", { name: "Login Required" })
+      .getByRole("button", { name: "Log in" });
     await loginButton.click();
     await this.checkAndReauthorizeGithubApp();
     await expect(async () => {
       await expect(loginButton).toBeVisible();
     }).toPass({
       intervals: [1_000],
-      timeout: 10_000
-    });    
+      timeout: 10_000,
+    });
   }
 
   getGitHub2FAOTP(userid: string): string {

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -167,7 +167,7 @@ export class Common {
   }
 
   async clickOnGHloginPopup() {
-    const loginButton = await getByRole('button', { name: 'Log in' })
+    const loginButton = await this.page.getByRole('dialog', {name: "Login Required"}).getByRole("button", {name: "Log in"})
     await loginButton.clickButton("Log in");
     await this.checkAndReauthorizeGithubApp();
     await this.page.waitForSelector(loginButton, {

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -166,9 +166,10 @@ export class Common {
   }
 
   async clickOnGHloginPopup() {
-    await this.uiHelper.clickButton("Log in");
+    const loginButton = await getByRole('button', { name: 'Log in' })
+    await loginButton.clickButton("Log in");
     await this.checkAndReauthorizeGithubApp();
-    await this.page.waitForSelector(this.uiHelper.getButtonSelector("Log in"), {
+    await this.page.waitForSelector(loginButton, {
       state: "hidden",
       timeout: 100000,
     });

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -161,6 +161,7 @@ export class Common {
       await frameLocator.waitFor({ state: "visible", timeout: 2000 });
       await this.clickOnGHloginPopup();
     } catch (error) {
+      console.log(JSON.stringify(error))
       if (force) throw error;
     }
   }

--- a/e2e-tests/playwright/utils/Common.ts
+++ b/e2e-tests/playwright/utils/Common.ts
@@ -167,13 +167,15 @@ export class Common {
   }
 
   async clickOnGHloginPopup() {
-    const loginButton = await this.page.getByRole('dialog', {name: "Login Required"}).getByRole("button", {name: "Log in"})
-    await loginButton.clickButton("Log in");
+    const loginButton = this.page.getByRole('dialog', {name: "Login Required"}).getByRole("button", {name: "Log in"})
+    await loginButton.click();
     await this.checkAndReauthorizeGithubApp();
-    await this.page.waitForSelector(loginButton, {
-      state: "hidden",
-      timeout: 100000,
-    });
+    await expect(async () => {
+      await expect(loginButton).toBeVisible();
+    }).toPass({
+      intervals: [1_000],
+      timeout: 10_000
+    });    
   }
 
   getGitHub2FAOTP(userid: string): string {


### PR DESCRIPTION
## Description

Improve Github popup login used in catalog-scaffoldedfromLink.spec.ts, which is making the e2e fail. 

## Which issue(s) does this PR fix

- Fixes [RHIDP-5209](https://issues.redhat.com/browse/RHIDP-5209)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
