### PR TITLE
chore(ci): allow release prefixes on pull request titles

### DIFF
--- a/.github/workflows/pr-semantic.yaml
+++ b/.github/workflows/pr-semantic.yaml
@@ -33,6 +33,7 @@ jobs:
             test
             revert
           requireScope: false
+          headerPattern: '^(?:\[release-\d+.\d+\] )?(\w*)(?:\(([\w$.\-* ]*)\))?: (.*)$'
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"


### PR DESCRIPTION
## Description

Hi @schultzp2020, this extra configuration to the Conventional Commits check will allow `/cherry-pick` PRs without renaming them.

This should work with this change:

```
fix: a small bugfix 
[release-1.4] fix: a small bugfix 
[WIP] [release-1.4] fix: a small bugfix 
```

The `headerPattern` default is defined here https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-commits-parser/src/options.ts#L17 

And I added the optional support for `[release-/d+./d+] ` prefix.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

I've tested the workflow here https://github.com/christoph-jerolimov/conventionalcommit-test/pulls
