### PR TITLE
[release-1.4] chore(ci): enable homepage plugin on ci setup

### DIFF
--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -97,7 +97,7 @@ global:
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-        disabled: true
+        disabled: false
       # Enable tech-radar plugin.
       - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
         disabled: false


### PR DESCRIPTION
## Description

This PR also enables the 'dynamic-home-page' plugin in 1.4 when running and testing the CI job with RBAC.

The plugin is enabled for customers **by default** and was disabled without any reason (a copy-paste issue by myself, I guess) in the RBAC setup.

And this confused people (for a good reason), so also if this doesn't touch our product, it might help to reduce noise in the future by fixing the CI config.

It was merged into main as part of #2089

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
