### PR TITLE
chore(metadata): backstage-community-plugin-topology should remain GA level support [ci skip] (RHIDP-5103)

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
@@ -62,7 +62,7 @@
     "directory": "dynamic-plugins/wrappers/backstage-community-plugin-topology"
   },
   "keywords": [
-    "support:tech-preview",
+    "support:production",
     "lifecycle:active"
   ],
   "homepage": "https://red.ht/rhdh",


### PR DESCRIPTION
### What does this PR do?

chore(metadata) backstage-community-plugin-topology should remain GA level support [ci skip]

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

Because this plugin was GA in 1.3, it should remain GA after moving to BCP repo. 

https://issues.redhat.com/browse/RHIDP-5103

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.