### PR TITLE
fix(wrappers): embed runtime dependencies

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
@@ -32,10 +32,11 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab-org",
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-catalog-backend-module-gitlab-org --embed-package @backstage/plugin-catalog-backend-module-gitlab",
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
+    "@backstage/plugin-catalog-backend-module-gitlab": "0.4.4",
     "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.2"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
@@ -36,11 +36,12 @@
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
     "clean-dynamic-sources": "yarn clean && rm -Rf node_modules",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-notifications-backend",
+    "export-dynamic": "janus-cli package export-dynamic-plugin --embed-package @backstage/plugin-notifications-backend --embed-package @backstage/plugin-signals-node",
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend": "0.4.2"
+    "@backstage/plugin-notifications-backend": "0.4.2",
+    "@backstage/plugin-signals-node": "0.1.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8357,6 +8357,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-signals-node@npm:0.1.13":
+  version: 0.1.13
+  resolution: "@backstage/plugin-signals-node@npm:0.1.13"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.1
+    "@backstage/config": ^1.2.0
+    "@backstage/plugin-auth-node": ^0.5.3
+    "@backstage/plugin-events-node": ^0.4.2
+    "@backstage/types": ^1.1.1
+    express: ^4.17.1
+    uuid: ^9.0.0
+    ws: ^8.18.0
+  checksum: 62a0c5364d55fbbe2ab21d64e298266e23d23d28e2388ef18915a42b6da3a5e112a29879c3abd5ba0c0d58ac1f59e186fd55d7e06d761da61d94ad151d0c0680
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-signals-node@npm:^0.1.13, @backstage/plugin-signals-node@npm:^0.1.14":
   version: 0.1.14
   resolution: "@backstage/plugin-signals-node@npm:0.1.14"
@@ -22923,6 +22940,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-gitlab-org@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
+    "@backstage/plugin-catalog-backend-module-gitlab": 0.4.4
     "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -23002,6 +23020,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/plugin-notifications-backend": 0.4.2
+    "@backstage/plugin-signals-node": 0.1.13
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown


### PR DESCRIPTION
## Description

This change updates the wrappers for the notification backend and catalog backend module for gitlab org to explicitly embed some packages that are needed at runtime, as the normal behavior of the janus-idp CLI for these dependencies are to move them to peer dependencies.

## Which issue(s) does this PR fix

- Fixes [RHIDP-5308](https://issues.redhat.com/browse/RHIDP-5308)
- Fixes https://issues.redhat.com/browse/RHIDP-5319
