### PR TITLE
chore(ci): use ephemeral AKS cluster with fallback

### DIFF
--- a/.ibm/pipelines/jobs/aks.sh
+++ b/.ibm/pipelines/jobs/aks.sh
@@ -4,25 +4,28 @@ handle_aks() {
   echo "Starting AKS deployment"
   for file in ${DIR}/cluster/aks/*.sh; do source $file; done
 
-  export K8S_CLUSTER_TOKEN=$(cat /tmp/secrets/AKS_CLUSTER_TOKEN)
-  export K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
-  export K8S_SERVICE_ACCOUNT_TOKEN=$K8S_CLUSTER_TOKEN_ENCODED
-  export OCM_CLUSTER_TOKEN=$K8S_CLUSTER_TOKEN_ENCODED
-
   export K8S_CLUSTER_ROUTER_BASE=$AKS_INSTANCE_DOMAIN_NAME
   export NAME_SPACE_K8S="showcase-k8s-ci-nightly"
   export NAME_SPACE_RBAC_K8S="showcase-rbac-k8s-ci-nightly"
 
   url="https://${K8S_CLUSTER_ROUTER_BASE}"
 
-  az_login
-  az_aks_start "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
-  az_aks_approuting_enable "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
-  az_aks_get_credentials "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
+  if ! kubectl auth whoami; then
+    export K8S_CLUSTER_TOKEN=$(cat /tmp/secrets/AKS_CLUSTER_TOKEN)
+    export K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
+    export K8S_SERVICE_ACCOUNT_TOKEN=$K8S_CLUSTER_TOKEN_ENCODED
+    export OCM_CLUSTER_TOKEN=$K8S_CLUSTER_TOKEN_ENCODED
 
-  export K8S_CLUSTER_URL=$(oc whoami --show-server)
-  export K8S_CLUSTER_API_SERVER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
-  export OCM_CLUSTER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
+    az_login
+    az_aks_start "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
+    az_aks_approuting_enable "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
+    az_aks_get_credentials "${AKS_NIGHTLY_CLUSTER_NAME}" "${AKS_NIGHTLY_CLUSTER_RESOURCEGROUP}"
+
+    export K8S_CLUSTER_URL=$(oc whoami --show-server)
+    export K8S_CLUSTER_API_SERVER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
+    export OCM_CLUSTER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
+  fi
+
 
   initiate_aks_deployment
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE_K8S}" "${url}"
@@ -32,5 +35,3 @@ handle_aks() {
   check_and_test "${RELEASE_NAME_RBAC}" "${NAME_SPACE_RBAC_K8S}" "${rbac_rhdh_base_url}"
   delete_namespace "${NAME_SPACE_RBAC_K8S}"
 }
-
-

--- a/.ibm/pipelines/jobs/aks.sh
+++ b/.ibm/pipelines/jobs/aks.sh
@@ -10,7 +10,10 @@ handle_aks() {
 
   url="https://${K8S_CLUSTER_ROUTER_BASE}"
 
-  if ! kubectl auth whoami; then
+  if kubectl auth whoami > /dev/null 2>&1; then
+    echo "Using an ephemeral AKS cluster."
+  else
+    echo "Falling back to a long-running AKS cluster."
     export K8S_CLUSTER_TOKEN=$(cat /tmp/secrets/AKS_CLUSTER_TOKEN)
     export K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
     export K8S_SERVICE_ACCOUNT_TOKEN=$K8S_CLUSTER_TOKEN_ENCODED
@@ -25,7 +28,6 @@ handle_aks() {
     export K8S_CLUSTER_API_SERVER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
     export OCM_CLUSTER_URL=$(printf "%s" "$K8S_CLUSTER_URL" | base64 | tr -d '\n')
   fi
-
 
   initiate_aks_deployment
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE_K8S}" "${url}"


### PR DESCRIPTION
## Description

This PR enables the use of an ephemeral AKS cluster. 

Cluster provisioning will be part of the job (configured in https://github.com/openshift/release/pull/59507). However, this PR needs to be merged first.

The fallback to a long-running cluster is kept.

## Which issue(s) does this PR fix

- Fixes [RHIDP-4763](https://issues.redhat.com/browse/RHIDP-4763)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
