### PR TITLE
chore(ci): fix droute error handling for nightly

### DIFF
--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -39,9 +39,9 @@ droute_send() {
   if [[ "${OPENSHIFT_CI}" != "true" ]]; then return 0; fi
   temp_kubeconfig=$(mktemp) # Create temporary KUBECONFIG to open second `oc` session
   ( # Open subshell
-    # if [ -n "${PULL_NUMBER:-}" ]; then
-    #   set +e
-    # fi
+    if [ -n "${PULL_NUMBER:-}" ]; then
+      set +e
+    fi
     export KUBECONFIG="$temp_kubeconfig"
     local droute_version="1.2.2"
     local release_name=$1

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -39,9 +39,9 @@ droute_send() {
   if [[ "${OPENSHIFT_CI}" != "true" ]]; then return 0; fi
   temp_kubeconfig=$(mktemp) # Create temporary KUBECONFIG to open second `oc` session
   ( # Open subshell
-    if [ -n "${PULL_NUMBER:-}" ]; then
-      set +e
-    fi
+    # if [ -n "${PULL_NUMBER:-}" ]; then
+    #   set +e
+    # fi
     export KUBECONFIG="$temp_kubeconfig"
     local droute_version="1.2.2"
     local release_name=$1

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -113,13 +113,13 @@ droute_send() {
         --username '${DATA_ROUTER_USERNAME}' \
         --password '${DATA_ROUTER_PASSWORD}' \
         --results '${temp_droute}/${JUNIT_RESULTS}' \
-        --verbose" 2>&1) &&
-        DATA_ROUTER_REQUEST_ID=$(echo "$output" | grep "request:" | awk '{print $2}') &&
-        [ -n "$DATA_ROUTER_REQUEST_ID" ]; then
-
-        echo "Test results successfully sent through Data Router."
-        echo "Request ID: $DATA_ROUTER_REQUEST_ID"
-        return 0
+        --verbose" 2>&1); then
+        if DATA_ROUTER_REQUEST_ID=$(echo "$output" | grep "request:" | awk '{print $2}') &&
+          [ -n "$DATA_ROUTER_REQUEST_ID" ]; then
+          echo "Test results successfully sent through Data Router."
+          echo "Request ID: $DATA_ROUTER_REQUEST_ID"
+          return 0
+        fi
       fi
 
       if ((i <= max_attempts)); then

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -107,6 +107,7 @@ droute_send() {
     local max_attempts=5
     local wait_seconds=1
     for ((i = 1; i <= max_attempts; i++)); do
+      echo "Attempt ${i} of ${max_attempts} to send test results through Data Router."
       if output=$(oc exec -n "${droute_project}" "${droute_pod_name}" -- /bin/bash -c "
         /tmp/droute-linux-amd64 send --metadata ${temp_droute}/${metadata_output} \
         --url '${DATA_ROUTER_URL}' \
@@ -123,12 +124,13 @@ droute_send() {
       fi
 
       if ((i <= max_attempts)); then
-        echo "Attempt ${i} of ${max_attempts}: Error sending test results through Data Router."
-        echo "Error details: $output"
+        echo "Data Router error details:"
+        echo "${output}"
         sleep "${wait_seconds}"
       else
         echo "Failed to send test results after ${max_attempts} attempts."
-        echo "Last error: $output"
+        echo "Last Data Router error details:"
+        echo "${output}"
         echo "Troubleshooting steps:"
         echo "1. Restart $droute_pod_name in $droute_project project/namespace"
         echo "2. Check the Data Router documentation: https://spaces.redhat.com/pages/viewpage.action?pageId=115488042"

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -119,15 +119,11 @@ droute_send() {
           [ -n "$DATA_ROUTER_REQUEST_ID" ]; then
           echo "Test results successfully sent through Data Router."
           echo "Request ID: $DATA_ROUTER_REQUEST_ID"
-          return 0
+          break
         fi
       fi
 
-      if ((i <= max_attempts)); then
-        echo "Data Router error details:"
-        echo "${output}"
-        sleep "${wait_seconds}"
-      else
+      if ((i == max_attempts)); then
         echo "Failed to send test results after ${max_attempts} attempts."
         echo "Last Data Router error details:"
         echo "${output}"
@@ -135,7 +131,6 @@ droute_send() {
         echo "1. Restart $droute_pod_name in $droute_project project/namespace"
         echo "2. Check the Data Router documentation: https://spaces.redhat.com/pages/viewpage.action?pageId=115488042"
         echo "3. Ask for help at Slack: #forum-dno-datarouter"
-        return 1
       fi
     done
 


### PR DESCRIPTION
## Description

Use better error handling for the Data Router. Previously, if there was any failure in the test and if the Data Router retry was triggered, it resulted in highlighting the error message from the Data Router, even though it was not actually an error.

## Which issue(s) does this PR fix

- Fixes [RHIDP-5392](https://issues.redhat.com/browse/RHIDP-5392)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
